### PR TITLE
Add testing framework (winn test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Winn language are documented here.
 
+## [Unreleased]
+
+### Testing Framework
+- **`winn test`** — run Winn tests from the CLI (`winn test` or `winn test <file>`)
+- **`use Winn.Test`** — marks a module as a test module
+- **`assert(expr)`** — assert a condition is true
+- **`assert_equal(expected, actual)`** — assert two values are strictly equal
+- Test discovery finds `test_*` functions automatically
+- Colorized pass/fail output with timing
+- Compiles `src/` before tests so project modules are available
+- Exit code 0 on all pass, 1 on any failure
+
+### Compiler
+- **`module_info/0` and `module_info/1`** — now generated for all compiled modules (fixes Core Erlang gap)
+
 ## [0.2.0] - 2026-03-28
 
 ### Language Features

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -39,6 +39,9 @@ main(Args) ->
             winn_repl:start(),
             halt(0);
 
+        {test, TestArgs} ->
+            run_tests(TestArgs);
+
         {deps, Sub} ->
             Result = run_deps(Sub),
             case Result of
@@ -67,6 +70,8 @@ parse_args(["compile", File])      -> {compile, [File]};
 parse_args(["run", File | Args])   -> {run, File, Args};
 parse_args(["start" | Args])       -> {start, Args};
 parse_args(["console" | _])        -> console;
+parse_args(["test"])                -> {test, []};
+parse_args(["test" | Args])        -> {test, Args};
 parse_args(["deps" | Sub])         -> {deps, Sub};
 parse_args(["version" | _])        -> version;
 parse_args(["-v" | _])             -> version;
@@ -297,9 +302,8 @@ tmp_dir() ->
     integer_to_list(erlang:unique_integer([positive])).
 
 ensure_dir(Dir) ->
-    case file:make_dir(Dir) of
+    case filelib:ensure_path(Dir) of
         ok              -> ok;
-        {error, eexist} -> ok;
         {error, Reason} -> {error, Reason}
     end.
 
@@ -307,6 +311,80 @@ cleanup_dir(Dir) ->
     Beams = filelib:wildcard(Dir ++ "/*.beam"),
     [file:delete(B) || B <- Beams],
     file:del_dir(Dir).
+
+%% ── Test runner ─────────────────────────────────────────────────────────
+
+run_tests(Args) ->
+    Files = find_test_files(Args),
+    case Files of
+        [] ->
+            io:format("No test files found.~n"),
+            halt(1);
+        _ ->
+            TmpDir = "_build/test",
+            ok = ensure_dir(TmpDir),
+            {Compiled, Errors} = compile_test_files(Files, TmpDir),
+            case Errors of
+                [] -> ok;
+                _ ->
+                    io:format("~B file(s) failed to compile.~n", [length(Errors)]),
+                    halt(1)
+            end,
+            Modules = load_test_beams(TmpDir, Compiled),
+            case winn_test:run_tests(Modules) of
+                ok    -> halt(0);
+                error -> halt(1)
+            end
+    end.
+
+find_test_files([]) ->
+    %% Find all .winn files in test/ directory
+    case filelib:is_dir("test") of
+        true  -> filelib:wildcard("test/*.winn");
+        false -> []
+    end;
+find_test_files(Paths) ->
+    %% Specific files passed as arguments
+    lists:filter(fun filelib:is_file/1, Paths).
+
+compile_test_files(Files, OutDir) ->
+    %% Also compile src/ first so test modules can call project modules
+    SrcFiles = case filelib:is_dir("src") of
+        true  -> filelib:wildcard("src/*.winn");
+        false -> []
+    end,
+    SrcDir = "_build/test/src",
+    ok = ensure_dir(SrcDir),
+    lists:foreach(fun(F) ->
+        case winn:compile_file(F, SrcDir) of
+            {ok, _} -> ok;
+            _ -> ok
+        end
+    end, SrcFiles),
+    %% Add src beam dir to code path
+    code:add_patha(SrcDir),
+    %% Compile test files
+    lists:foldl(fun(File, {Ok, Err}) ->
+        case winn:compile_file(File, OutDir) of
+            {ok, _} -> {[File | Ok], Err};
+            {error, Reason} ->
+                io:format("Error compiling ~s: ~p~n", [File, Reason]),
+                {Ok, [File | Err]}
+        end
+    end, {[], []}, Files).
+
+load_test_beams(Dir, _Compiled) ->
+    code:add_patha(Dir),
+    Beams = filelib:wildcard(Dir ++ "/*.beam"),
+    lists:filtermap(fun(BeamPath) ->
+        ModStr = filename:basename(BeamPath, ".beam"),
+        Mod = list_to_atom(ModStr),
+        code:purge(Mod),
+        case code:load_file(Mod) of
+            {module, Mod} -> {true, Mod};
+            _ -> false
+        end
+    end, Beams).
 
 %% ── Deps subcommand ─────────────────────────────────────────────────────
 
@@ -358,6 +436,8 @@ print_usage() ->
         "  winn run <file>         Compile and run a single .winn file~n"
         "  winn start              Compile project and start (keeps VM alive)~n"
         "  winn start <module>     Start with a specific module~n"
+        "  winn test               Run all tests in test/~n"
+        "  winn test <file>        Run a specific test file~n"
         "  winn deps               Manage dependencies~n"
         "  winn console            Interactive console~n"
         "  winn version            Show version~n"

--- a/apps/winn/src/winn_codegen.erl
+++ b/apps/winn/src/winn_codegen.erl
@@ -28,7 +28,21 @@ gen_module({module, _Line, Name, Body}) ->
 
     Defs = [gen_function(F) || F <- Functions],
 
-    cerl:c_module(ModName, Exports, Attrs, Defs).
+    %% Add module_info/0 and module_info/1 (not auto-generated for from_core).
+    MI0Var = cerl:c_var({module_info, 0}),
+    MI0Fun = cerl:c_fun([],
+        cerl:c_call(cerl:c_atom(erlang), cerl:c_atom(get_module_info),
+                    [ModName])),
+    MI1Arg = cerl:c_var('X'),
+    MI1Var = cerl:c_var({module_info, 1}),
+    MI1Fun = cerl:c_fun([MI1Arg],
+        cerl:c_call(cerl:c_atom(erlang), cerl:c_atom(get_module_info),
+                    [ModName, MI1Arg])),
+
+    AllExports = Exports ++ [MI0Var, MI1Var],
+    AllDefs    = Defs ++ [{MI0Var, MI0Fun}, {MI1Var, MI1Fun}],
+
+    cerl:c_module(ModName, AllExports, Attrs, AllDefs).
 
 %% ── Function ───────────────────────────────────────────────────────────────
 
@@ -85,6 +99,11 @@ gen_expr({call, _Line, Fun, Args}) when
         Fun =:= inspect ->
     CArgs = [gen_expr(A) || A <- Args],
     cerl:c_call(cerl:c_atom(winn_runtime), cerl:c_atom(Fun), CArgs);
+%% Test assertion builtins — routed to winn_test module.
+gen_expr({call, _Line, Fun, Args}) when
+        Fun =:= assert; Fun =:= assert_equal ->
+    CArgs = [gen_expr(A) || A <- Args],
+    cerl:c_call(cerl:c_atom(winn_test), cerl:c_atom(Fun), CArgs);
 gen_expr({call, _Line, Fun, Args}) ->
     Op    = cerl:c_var({fn_atom(Fun), length(Args)}),
     CArgs = [gen_expr(A) || A <- Args],

--- a/apps/winn/src/winn_test.erl
+++ b/apps/winn/src/winn_test.erl
@@ -1,0 +1,120 @@
+%% winn_test.erl
+%% Testing framework runtime: assertions and test runner.
+
+-module(winn_test).
+-export([assert/1, assert_equal/2, run_tests/1]).
+
+%% ── Assertions ───────────────────────────────────────────────────────────────
+
+assert(true) -> ok;
+assert(false) ->
+    error({assertion_failed, #{expected => true, got => false}});
+assert(Val) ->
+    error({assertion_failed, #{expected => true, got => Val}}).
+
+assert_equal(Expected, Actual) when Expected =:= Actual -> ok;
+assert_equal(Expected, Actual) ->
+    error({assertion_failed, #{expected => Expected, got => Actual}}).
+
+%% ── Test Runner ──────────────────────────────────────────────────────────────
+
+-spec run_tests([module()]) -> ok | error.
+run_tests(Modules) ->
+    StartTime = erlang:monotonic_time(millisecond),
+    Results = lists:flatmap(fun run_module/1, Modules),
+    EndTime = erlang:monotonic_time(millisecond),
+    Elapsed = EndTime - StartTime,
+    format_results(Results, Elapsed).
+
+%% ── Internal ─────────────────────────────────────────────────────────────────
+
+run_module(Mod) ->
+    Exports = Mod:module_info(exports),
+    TestFuns = [F || {F, 0} <- Exports, is_test_function(F)],
+    [run_one(Mod, F) || F <- TestFuns].
+
+is_test_function(Name) ->
+    case atom_to_list(Name) of
+        "test_" ++ _ -> true;
+        _ -> false
+    end.
+
+run_one(Mod, Fun) ->
+    try
+        Mod:Fun(),
+        {pass, Mod, Fun}
+    catch
+        error:{assertion_failed, Info} ->
+            {fail, Mod, Fun, {assertion_failed, Info}};
+        Class:Reason:Stack ->
+            {fail, Mod, Fun, {Class, Reason, Stack}}
+    end.
+
+format_results(Results, Elapsed) ->
+    UseColor = use_color(),
+    Passes = [R || {pass, _, _} = R <- Results],
+    Fails  = [R || {fail, _, _, _} = R <- Results],
+    PassCount = length(Passes),
+    FailCount = length(Fails),
+    Total = PassCount + FailCount,
+
+    %% Print each result
+    lists:foreach(fun(R) -> print_result(R, UseColor) end, Results),
+
+    %% Print summary
+    io:format("~n"),
+    if FailCount > 0 ->
+        io:format("~sFailed ~B of ~B tests~s (~Bms)~n",
+                  [color(red, UseColor), FailCount, Total,
+                   color(reset, UseColor), Elapsed]);
+       true ->
+        io:format("~s~B tests, 0 failures~s (~Bms)~n",
+                  [color(green, UseColor), Total,
+                   color(reset, UseColor), Elapsed])
+    end,
+
+    case FailCount of
+        0 -> ok;
+        _ -> error
+    end.
+
+print_result({pass, Mod, Fun}, UseColor) ->
+    io:format("  ~s.~s ~n", [color(green, UseColor), color(reset, UseColor)]),
+    io:format("    ~s:~s~n", [Mod, Fun]);
+print_result({fail, Mod, Fun, {assertion_failed, Info}}, UseColor) ->
+    io:format("  ~sF~s ~s:~s~n",
+              [color(red, UseColor), color(reset, UseColor), Mod, Fun]),
+    case maps:find(expected, Info) of
+        {ok, Expected} ->
+            Actual = maps:get(got, Info, undefined),
+            io:format("    expected: ~p~n", [Expected]),
+            io:format("         got: ~p~n", [Actual]);
+        error -> ok
+    end;
+print_result({fail, Mod, Fun, {Class, Reason, _Stack}}, UseColor) ->
+    io:format("  ~sF~s ~s:~s~n",
+              [color(red, UseColor), color(reset, UseColor), Mod, Fun]),
+    io:format("    ~s:~p~n", [Class, Reason]).
+
+%% ── Color helpers ────────────────────────────────────────────────────────────
+
+use_color() ->
+    case os:getenv("NO_COLOR") of
+        false -> is_tty();
+        _ -> false
+    end.
+
+is_tty() ->
+    case os:type() of
+        {unix, _} ->
+            case io:columns() of
+                {ok, _} -> true;
+                _ -> false
+            end;
+        _ -> false
+    end.
+
+color(green, true) -> "\e[32m";
+color(red, true)   -> "\e[31m";
+color(reset, true) -> "\e[0m";
+color(_, false)    -> "".

--- a/apps/winn/src/winn_transform.erl
+++ b/apps/winn/src/winn_transform.erl
@@ -83,6 +83,9 @@ expand_use(Line, 'Winn', 'WebSocket', _ModName) ->
 expand_use(Line, 'Winn', 'Task', _ModName) ->
     Attr = {behaviour_attr, Line, winn_task},
     {behaviour_only, Attr};
+expand_use(Line, 'Winn', 'Test', _ModName) ->
+    Attr = {behaviour_attr, Line, winn_test},
+    {behaviour_only, Attr};
 expand_use(_Line, 'Winn', 'Schema', _ModName) ->
     {schema_use, none}.
 

--- a/apps/winn/test/winn_test_framework_tests.erl
+++ b/apps/winn/test/winn_test_framework_tests.erl
@@ -1,0 +1,136 @@
+%% winn_test_framework_tests.erl
+%% Tests for the Winn testing framework (winn test).
+
+-module(winn_test_framework_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Helpers ──────────────────────────────────────────────────────────────────
+
+compile_and_load(Source) ->
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% ── Assert runtime tests ────────────────────────────────────────────────────
+
+assert_true_test() ->
+    ?assertEqual(ok, winn_test:assert(true)).
+
+assert_false_test() ->
+    ?assertError({assertion_failed, #{expected := true, got := false}},
+                 winn_test:assert(false)).
+
+assert_non_boolean_test() ->
+    ?assertError({assertion_failed, #{expected := true, got := 42}},
+                 winn_test:assert(42)).
+
+assert_equal_pass_test() ->
+    ?assertEqual(ok, winn_test:assert_equal(42, 42)).
+
+assert_equal_fail_test() ->
+    ?assertError({assertion_failed, #{expected := 42, got := 99}},
+                 winn_test:assert_equal(42, 99)).
+
+assert_equal_string_test() ->
+    ?assertEqual(ok, winn_test:assert_equal(<<"hello">>, <<"hello">>)).
+
+%% ── Transform: use Winn.Test ────────────────────────────────────────────────
+
+use_winn_test_transform_test() ->
+    Source = "module TestTransformCheck\n"
+             "  use Winn.Test\n"
+             "\n"
+             "  def test_example()\n"
+             "    1 + 1\n"
+             "  end\n"
+             "end\n",
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    %% Should contain a behaviour_attr for winn_test
+    [{module, _, _, Body}] = Transformed,
+    BehaviourAttrs = [B || {behaviour_attr, _, B} <- Body],
+    ?assert(lists:member(winn_test, BehaviourAttrs)).
+
+%% ── End-to-end: compile and run assert ──────────────────────────────────────
+
+assert_compiles_and_passes_test() ->
+    Source = "module TestAssertPass\n"
+             "  use Winn.Test\n"
+             "\n"
+             "  def test_truth()\n"
+             "    assert(1 == 1)\n"
+             "  end\n"
+             "end\n",
+    Mod = compile_and_load(Source),
+    ?assertEqual(ok, Mod:test_truth()).
+
+assert_compiles_and_fails_test() ->
+    Source = "module TestAssertFail\n"
+             "  use Winn.Test\n"
+             "\n"
+             "  def test_lie()\n"
+             "    assert(1 == 2)\n"
+             "  end\n"
+             "end\n",
+    Mod = compile_and_load(Source),
+    ?assertError({assertion_failed, _}, Mod:test_lie()).
+
+assert_equal_compiles_test() ->
+    Source = "module TestAssertEqualComp\n"
+             "  use Winn.Test\n"
+             "\n"
+             "  def test_eq()\n"
+             "    assert_equal(42, 21 + 21)\n"
+             "  end\n"
+             "end\n",
+    Mod = compile_and_load(Source),
+    ?assertEqual(ok, Mod:test_eq()).
+
+assert_equal_fail_compiles_test() ->
+    Source = "module TestAssertEqualFail\n"
+             "  use Winn.Test\n"
+             "\n"
+             "  def test_neq()\n"
+             "    assert_equal(42, 99)\n"
+             "  end\n"
+             "end\n",
+    Mod = compile_and_load(Source),
+    ?assertError({assertion_failed, _}, Mod:test_neq()).
+
+%% ── Test runner: discover and run ───────────────────────────────────────────
+
+run_tests_all_pass_test() ->
+    Source = "module TestRunnerPass\n"
+             "  use Winn.Test\n"
+             "\n"
+             "  def test_one()\n"
+             "    assert(true)\n"
+             "  end\n"
+             "\n"
+             "  def test_two()\n"
+             "    assert_equal(4, 2 + 2)\n"
+             "  end\n"
+             "end\n",
+    Mod = compile_and_load(Source),
+    ?assertEqual(ok, winn_test:run_tests([Mod])).
+
+run_tests_with_failure_test() ->
+    Source = "module TestRunnerMixed\n"
+             "  use Winn.Test\n"
+             "\n"
+             "  def test_pass()\n"
+             "    assert(true)\n"
+             "  end\n"
+             "\n"
+             "  def test_fail()\n"
+             "    assert(false)\n"
+             "  end\n"
+             "end\n",
+    Mod = compile_and_load(Source),
+    ?assertEqual(error, winn_test:run_tests([Mod])).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -144,6 +144,54 @@ Use `winn start` for:
 
 ---
 
+### `winn test [file]`
+
+Run Winn tests.
+
+```sh
+# Run all tests in test/
+winn test
+
+# Run a specific test file
+winn test test/math_test.winn
+```
+
+Write tests using `use Winn.Test`:
+
+```winn
+module MathTest
+  use Winn.Test
+
+  def test_addition()
+    assert(1 + 1 == 2)
+  end
+
+  def test_string_equality()
+    result = "hello" <> " world"
+    assert_equal("hello world", result)
+  end
+end
+```
+
+**Assertions:**
+
+| Function | Description |
+|----------|-------------|
+| `assert(expr)` | Passes if `expr` is `true` |
+| `assert_equal(expected, actual)` | Passes if `expected =:= actual` |
+
+**How it works:**
+
+1. Compiles all `test/*.winn` files (and `src/*.winn` for project modules)
+2. Loads compiled beams into the VM
+3. Discovers functions named `test_*` in test modules
+4. Runs each test function, catches assertion failures
+5. Prints colorized pass/fail results with timing
+
+Exit code is 0 when all tests pass, 1 on any failure.
+
+---
+
 ### `winn deps`
 
 Manage project dependencies.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -349,3 +349,35 @@ Also available via module prefix:
 
 - `String.to_integer(str)` — parse integer
 - `String.to_float(str)` — parse float
+
+## Testing
+
+### `assert(expr)`
+Assert that `expr` is `true`. Raises an assertion error on `false`.
+
+```winn
+assert(1 + 1 == 2)
+```
+
+### `assert_equal(expected, actual)`
+Assert that two values are strictly equal (`=:=`). On failure, shows the expected and actual values.
+
+```winn
+assert_equal("hello", String.downcase("HELLO"))
+```
+
+### `use Winn.Test`
+Marks a module as a test module. Test functions must be named `test_*` with zero arguments.
+
+```winn
+module UserTest
+  use Winn.Test
+
+  def test_greeting()
+    result = "Hello, " <> "Alice"
+    assert_equal("Hello, Alice", result)
+  end
+end
+```
+
+Run with `winn test`. See [CLI Reference](cli.md#winn-test-file) for details.


### PR DESCRIPTION
## Summary
- Adds `winn test` CLI command to run Winn-native tests
- Adds `use Winn.Test` directive, `assert/1` and `assert_equal/2` builtins
- Test discovery finds `test_*` functions, colorized pass/fail output, exit codes
- Generates `module_info/0,1` for all compiled modules (Core Erlang fix)
- 13 new EUnit tests (330 total, 0 failures)

Closes #8

## Test plan
- [x] `rebar3 eunit` — 330 tests, 0 failures
- [x] `rebar3 escriptize && winn test` — end-to-end with sample .winn test file
- [x] Verified exit code 0 on all pass, 1 on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)