### PR TITLE
Add hot code reloading with live terminal dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Winn language are documented here.
 
+## [Unreleased]
+
+### Tooling
+- **`winn watch`** — file watcher with hot code reloading and live terminal dashboard
+- **Live dashboard** — shows per-module status, reload times, compile errors inline, reload count, and uptime
+- **`winn watch --start`** — watch mode + starts the app (OTP apps, calls main)
+
 ## [0.2.0] - 2026-03-28
 
 ### Language Features

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -39,6 +39,10 @@ main(Args) ->
             winn_repl:start(),
             halt(0);
 
+        {watch, WatchArgs} ->
+            Opts = #{start => lists:member("--start", WatchArgs)},
+            winn_watch:start(Opts);
+
         {deps, Sub} ->
             Result = run_deps(Sub),
             case Result of
@@ -67,6 +71,7 @@ parse_args(["compile", File])      -> {compile, [File]};
 parse_args(["run", File | Args])   -> {run, File, Args};
 parse_args(["start" | Args])       -> {start, Args};
 parse_args(["console" | _])        -> console;
+parse_args(["watch" | Args])       -> {watch, Args};
 parse_args(["deps" | Sub])         -> {deps, Sub};
 parse_args(["version" | _])        -> version;
 parse_args(["-v" | _])             -> version;
@@ -358,6 +363,8 @@ print_usage() ->
         "  winn run <file>         Compile and run a single .winn file~n"
         "  winn start              Compile project and start (keeps VM alive)~n"
         "  winn start <module>     Start with a specific module~n"
+        "  winn watch              Watch files and hot-reload with live dashboard~n"
+        "  winn watch --start      Watch + start the app~n"
         "  winn deps               Manage dependencies~n"
         "  winn console            Interactive console~n"
         "  winn version            Show version~n"

--- a/apps/winn/src/winn_watch.erl
+++ b/apps/winn/src/winn_watch.erl
@@ -1,0 +1,320 @@
+%% winn_watch.erl
+%% File watcher with hot code reloading and live terminal dashboard.
+
+-module(winn_watch).
+-export([start/1, format_dashboard/1, check_files/1, format_elapsed/1, format_uptime/1]).
+
+-define(POLL_INTERVAL, 500).
+-define(REDRAW_INTERVAL, 1000).
+
+%% ── Public API ───────────────────────────────────────────────────────────────
+
+-spec start(#{start => boolean()}) -> no_return().
+start(Opts) ->
+    OutDir = "ebin",
+    ok = filelib:ensure_path(OutDir),
+    code:add_patha(OutDir),
+
+    %% Initial compile
+    Files = discover_files(),
+    case Files of
+        [] ->
+            io:format("No .winn files found in src/ or current directory.~n"),
+            halt(1);
+        _ -> ok
+    end,
+
+    {Modules, Mtimes} = initial_compile(Files, OutDir),
+
+    %% Optionally start the app
+    case maps:get(start, Opts, false) of
+        true  -> start_app(Files);
+        false -> ok
+    end,
+
+    State = #{
+        files      => Mtimes,
+        modules    => Modules,
+        reloads    => 0,
+        errors     => count_errors(Modules),
+        start_time => erlang:monotonic_time(second),
+        out_dir    => OutDir,
+        last_draw  => 0
+    },
+
+    %% Clear screen and enter watch loop
+    io:format("\e[2J\e[H"),
+    watch_loop(State).
+
+%% ── Watch loop ──────────────────────────────────────────────────────────────
+
+watch_loop(State) ->
+    Now = erlang:monotonic_time(second),
+    LastDraw = maps:get(last_draw, State),
+
+    %% Redraw dashboard every second
+    State2 = case (Now - LastDraw) >= 1 of
+        true ->
+            draw_dashboard(State),
+            State#{last_draw => Now};
+        false ->
+            State
+    end,
+
+    timer:sleep(?POLL_INTERVAL),
+
+    %% Check for file changes
+    ChangedFiles = check_files(State2),
+    State3 = lists:foldl(fun(File, S) ->
+        recompile_and_reload(File, S)
+    end, State2, ChangedFiles),
+
+    %% Update mtimes
+    State4 = update_mtimes(State3),
+
+    watch_loop(State4).
+
+%% ── File discovery and mtime tracking ───────────────────────────────────────
+
+discover_files() ->
+    SrcFiles = filelib:wildcard("src/*.winn"),
+    case SrcFiles of
+        [] -> filelib:wildcard("*.winn");
+        _  -> SrcFiles
+    end.
+
+get_mtime(File) ->
+    case file:read_file_info(File, [{time, posix}]) of
+        {ok, Info} -> element(6, Info);  % mtime field in file_info
+        _ -> 0
+    end.
+
+check_files(#{files := Mtimes}) ->
+    CurrentFiles = discover_files(),
+    lists:filter(fun(File) ->
+        CurrentMtime = get_mtime(File),
+        case maps:get(File, Mtimes, undefined) of
+            undefined    -> true;   % new file
+            OldMtime     -> CurrentMtime > OldMtime
+        end
+    end, CurrentFiles).
+
+update_mtimes(#{files := Mtimes} = State) ->
+    CurrentFiles = discover_files(),
+    NewMtimes = lists:foldl(fun(File, Acc) ->
+        maps:put(File, get_mtime(File), Acc)
+    end, Mtimes, CurrentFiles),
+    State#{files => NewMtimes}.
+
+%% ── Compilation and hot reload ──────────────────────────────────────────────
+
+initial_compile(Files, OutDir) ->
+    lists:foldl(fun(File, {Mods, Mtimes}) ->
+        Mtime = get_mtime(File),
+        ModName = detect_module(File),
+        case winn:compile_file(File, OutDir) of
+            {ok, _} ->
+                code:purge(ModName),
+                code:load_file(ModName),
+                {maps:put(ModName, {ok, erlang:monotonic_time(second)}, Mods),
+                 maps:put(File, Mtime, Mtimes)};
+            {error, Reason} ->
+                ErrMsg = format_error(Reason),
+                {maps:put(ModName, {error, ErrMsg, erlang:monotonic_time(second)}, Mods),
+                 maps:put(File, Mtime, Mtimes)}
+        end
+    end, {#{}, #{}}, Files).
+
+recompile_and_reload(File, #{modules := Mods, reloads := Reloads,
+                              errors := Errors, out_dir := OutDir} = State) ->
+    ModName = detect_module(File),
+    case winn:compile_file(File, OutDir) of
+        {ok, _} ->
+            code:purge(ModName),
+            code:load_file(ModName),
+            NewMods = maps:put(ModName, {ok, erlang:monotonic_time(second)}, Mods),
+            WasError = case maps:get(ModName, Mods, undefined) of
+                {error, _, _} -> true;
+                _ -> false
+            end,
+            NewErrors = case WasError of true -> Errors - 1; false -> Errors end,
+            State#{modules => NewMods, reloads => Reloads + 1, errors => NewErrors};
+        {error, Reason} ->
+            ErrMsg = format_error(Reason),
+            NewMods = maps:put(ModName, {error, ErrMsg, erlang:monotonic_time(second)}, Mods),
+            WasOk = case maps:get(ModName, Mods, undefined) of
+                {ok, _} -> true;
+                undefined -> true;
+                _ -> false
+            end,
+            NewErrors = case WasOk of true -> Errors + 1; false -> Errors end,
+            State#{modules => NewMods, errors => NewErrors}
+    end.
+
+detect_module(File) ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            Source = binary_to_list(Bin),
+            case re:run(Source, "^\\s*module\\s+([A-Z][a-zA-Z0-9_.]*)",
+                        [{capture, [1], list}, multiline]) of
+                {match, [ModStr]} ->
+                    list_to_atom(string:lowercase(ModStr));
+                nomatch ->
+                    list_to_atom(filename:basename(File, ".winn"))
+            end;
+        _ ->
+            list_to_atom(filename:basename(File, ".winn"))
+    end.
+
+format_error({file_read, _Path, Reason}) ->
+    io_lib:format("~p", [Reason]);
+format_error({Line, winn_parser, Msg}) ->
+    io_lib:format("line ~B: ~s", [Line, Msg]);
+format_error(Reason) when is_list(Reason) ->
+    Reason;
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+count_errors(Mods) ->
+    maps:fold(fun(_, {error, _, _}, Acc) -> Acc + 1;
+                 (_, _, Acc) -> Acc end, 0, Mods).
+
+%% ── App startup (mirrors winn_cli:start_project) ───────────────────────────
+
+start_app(Files) ->
+    add_dep_paths(),
+    start_otp_apps(),
+    case Files of
+        [First | _] ->
+            ModAtom = detect_module(First),
+            case erlang:function_exported(ModAtom, main, 0) of
+                true  -> spawn(fun() -> ModAtom:main() end);
+                false ->
+                    case erlang:function_exported(ModAtom, main, 1) of
+                        true  -> spawn(fun() -> ModAtom:main([]) end);
+                        false -> ok
+                    end
+            end;
+        _ -> ok
+    end.
+
+add_dep_paths() ->
+    Paths = filelib:wildcard("_build/default/lib/*/ebin")
+         ++ filelib:wildcard("_build/prod/lib/*/ebin"),
+    [code:add_patha(P) || P <- Paths].
+
+start_otp_apps() ->
+    Apps = [crypto, asn1, public_key, ssl, inets],
+    lists:foreach(fun(App) ->
+        application:ensure_all_started(App)
+    end, Apps).
+
+%% ── Dashboard rendering ─────────────────────────────────────────────────────
+
+draw_dashboard(State) ->
+    Output = format_dashboard(State),
+    io:format("\e[H~ts", [Output]).
+
+format_dashboard(#{modules := Mods, reloads := Reloads,
+                    errors := Errors, start_time := StartTime}) ->
+    Now = erlang:monotonic_time(second),
+    Uptime = Now - StartTime,
+    ModCount = maps:size(Mods),
+    Width = 50,
+
+    %% Header
+    Title = " Winn Watch ",
+    PadLen = Width - length(Title) - 2,
+    Header = io_lib:format("\e[1m~ts~ts~ts~ts\e[0m~n",
+        [[$\x{250C}, $\x{2500}], Title,
+         lists:duplicate(max(0, PadLen), $\x{2500}), [$\x{2510}]]),
+
+    %% Subtitle
+    SubText = io_lib:format(" Watching src/ (~B module~s)", [ModCount, plural(ModCount)]),
+    SubLine = pad_line(SubText, Width),
+
+    %% Blank line
+    BlankLine = pad_line("", Width),
+
+    %% Module lines
+    SortedMods = lists:sort(maps:to_list(Mods)),
+    ModLines = lists:flatmap(fun({ModName, Status}) ->
+        format_module_line(ModName, Status, Now, Width)
+    end, SortedMods),
+
+    %% Footer stats
+    StatsText = io_lib:format(" Reloads: ~B  Errors: ~B  Uptime: ~s",
+        [Reloads, Errors, format_uptime(Uptime)]),
+    StatsLine = pad_line(StatsText, Width),
+
+    %% Bottom border
+    Bottom = io_lib:format("\e[1m~ts~ts~ts\e[0m~n",
+        [[$\x{2514}], lists:duplicate(Width - 2, $\x{2500}), [$\x{2518}]]),
+
+    lists:flatten([Header, SubLine, BlankLine | ModLines] ++ [BlankLine, StatsLine, Bottom]).
+
+format_module_line(ModName, {ok, ReloadTime}, Now, Width) ->
+    Elapsed = format_elapsed(Now - ReloadTime),
+    ModStr = atom_to_list(ModName),
+    PaddedName = pad_right(ModStr, 14),
+    Text = io_lib:format(" \e[32m\x{2713}\e[0m ~ts reloaded ~ts", [PaddedName, Elapsed]),
+    [pad_line_ansi(Text, Width)];
+format_module_line(ModName, {error, ErrMsg, _Since}, _Now, Width) ->
+    ModStr = atom_to_list(ModName),
+    PaddedName = pad_right(ModStr, 14),
+    Text = io_lib:format(" \e[31m\x{2717}\e[0m ~ts \e[31mcompile error\e[0m", [PaddedName]),
+    ErrText = io_lib:format("   \x{2514} ~ts", [truncate(lists:flatten(ErrMsg), 35)]),
+    [pad_line_ansi(Text, Width), pad_line_ansi(ErrText, Width)].
+
+%% ── Formatting helpers ──────────────────────────────────────────────────────
+
+format_elapsed(Secs) when Secs < 0 -> "just now";
+format_elapsed(0) -> "just now";
+format_elapsed(Secs) when Secs < 60 ->
+    io_lib:format("~Bs ago", [Secs]);
+format_elapsed(Secs) when Secs < 3600 ->
+    io_lib:format("~Bm ~Bs ago", [Secs div 60, Secs rem 60]);
+format_elapsed(Secs) ->
+    io_lib:format("~Bh ~Bm ago", [Secs div 3600, (Secs rem 3600) div 60]).
+
+format_uptime(Secs) when Secs < 60 ->
+    io_lib:format("~Bs", [Secs]);
+format_uptime(Secs) when Secs < 3600 ->
+    io_lib:format("~Bm ~Bs", [Secs div 60, Secs rem 60]);
+format_uptime(Secs) ->
+    io_lib:format("~Bh ~Bm", [Secs div 3600, (Secs rem 3600) div 60]).
+
+pad_line(Text, Width) ->
+    Flat = lists:flatten(Text),
+    Len = string:length(Flat),
+    Pad = max(0, Width - 2 - Len),
+    io_lib:format("\x{2502}~ts~ts\x{2502}~n", [Flat, lists:duplicate(Pad, $\s)]).
+
+pad_line_ansi(Text, Width) ->
+    %% ANSI escape codes don't count toward visible width
+    Flat = lists:flatten(Text),
+    VisLen = visible_length(Flat),
+    Pad = max(0, Width - 2 - VisLen),
+    io_lib:format("\x{2502}~ts~ts\x{2502}~n", [Flat, lists:duplicate(Pad, $\s)]).
+
+visible_length(Str) ->
+    %% Strip ANSI escape sequences to calculate visible width
+    Re = "\e\\[[0-9;]*m",
+    Stripped = re:replace(Str, Re, "", [global, unicode, {return, list}]),
+    string:length(Stripped).
+
+pad_right(Str, Width) ->
+    Len = string:length(Str),
+    case Len >= Width of
+        true  -> Str;
+        false -> Str ++ lists:duplicate(Width - Len, $\s)
+    end.
+
+truncate(Str, MaxLen) ->
+    case string:length(Str) > MaxLen of
+        true  -> string:slice(Str, 0, MaxLen - 3) ++ "...";
+        false -> Str
+    end.
+
+plural(1) -> "";
+plural(_) -> "s".

--- a/apps/winn/test/winn_watch_tests.erl
+++ b/apps/winn/test/winn_watch_tests.erl
@@ -1,0 +1,91 @@
+%% winn_watch_tests.erl
+%% Tests for the file watcher and live dashboard (#11).
+
+-module(winn_watch_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Format helpers ──────────────────────────────────────────────────────────
+
+format_elapsed_just_now_test() ->
+    ?assertEqual("just now", lists:flatten(winn_watch:format_elapsed(0))).
+
+format_elapsed_seconds_test() ->
+    ?assertEqual("5s ago", lists:flatten(winn_watch:format_elapsed(5))).
+
+format_elapsed_minutes_test() ->
+    ?assertEqual("2m 30s ago", lists:flatten(winn_watch:format_elapsed(150))).
+
+format_elapsed_hours_test() ->
+    ?assertEqual("1h 5m ago", lists:flatten(winn_watch:format_elapsed(3900))).
+
+format_uptime_seconds_test() ->
+    ?assertEqual("45s", lists:flatten(winn_watch:format_uptime(45))).
+
+format_uptime_minutes_test() ->
+    ?assertEqual("3m 15s", lists:flatten(winn_watch:format_uptime(195))).
+
+format_uptime_hours_test() ->
+    ?assertEqual("2h 10m", lists:flatten(winn_watch:format_uptime(7800))).
+
+%% ── Dashboard rendering ────────────────────────────────────────────────────
+
+dashboard_contains_module_names_test() ->
+    Now = erlang:monotonic_time(second),
+    State = #{
+        modules    => #{myapp => {ok, Now}, auth => {ok, Now - 5}},
+        reloads    => 3,
+        errors     => 0,
+        start_time => Now - 60,
+        files      => #{}
+    },
+    Output = lists:flatten(winn_watch:format_dashboard(State)),
+    ?assert(string:find(Output, "myapp") =/= nomatch),
+    ?assert(string:find(Output, "auth") =/= nomatch).
+
+dashboard_shows_error_test() ->
+    Now = erlang:monotonic_time(second),
+    State = #{
+        modules    => #{broken => {error, "line 5: syntax error", Now}},
+        reloads    => 1,
+        errors     => 1,
+        start_time => Now - 30,
+        files      => #{}
+    },
+    Output = lists:flatten(winn_watch:format_dashboard(State)),
+    ?assert(string:find(Output, "broken") =/= nomatch),
+    ?assert(string:find(Output, "compile error") =/= nomatch),
+    ?assert(string:find(Output, "syntax error") =/= nomatch).
+
+dashboard_shows_stats_test() ->
+    Now = erlang:monotonic_time(second),
+    State = #{
+        modules    => #{app => {ok, Now}},
+        reloads    => 7,
+        errors     => 0,
+        start_time => Now - 120,
+        files      => #{}
+    },
+    Output = lists:flatten(winn_watch:format_dashboard(State)),
+    ?assert(string:find(Output, "Reloads: 7") =/= nomatch),
+    ?assert(string:find(Output, "Errors: 0") =/= nomatch),
+    ?assert(string:find(Output, "Uptime:") =/= nomatch).
+
+dashboard_shows_winn_watch_title_test() ->
+    Now = erlang:monotonic_time(second),
+    State = #{
+        modules    => #{},
+        reloads    => 0,
+        errors     => 0,
+        start_time => Now,
+        files      => #{}
+    },
+    Output = lists:flatten(winn_watch:format_dashboard(State)),
+    ?assert(string:find(Output, "Winn Watch") =/= nomatch).
+
+%% ── File change detection ───────────────────────────────────────────────────
+
+check_files_detects_no_changes_test() ->
+    %% With no files in state and no .winn files in cwd, should return []
+    State = #{files => #{"nonexistent.winn" => 99999999999}},
+    Changed = winn_watch:check_files(State),
+    ?assertEqual([], Changed).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -144,6 +144,42 @@ Use `winn start` for:
 
 ---
 
+### `winn watch`
+
+Watch source files and hot-reload modules on change with a live terminal dashboard.
+
+```sh
+# Watch and recompile only
+winn watch
+
+# Watch + start the app (like winn start but with auto-reload)
+winn watch --start
+```
+
+The dashboard shows:
+
+```
+┌─ Winn Watch ─────────────────────────────────┐
+│ Watching src/ (3 modules)                     │
+│                                               │
+│  ✓ Api          reloaded 2s ago               │
+│  ✓ Auth         reloaded 14s ago              │
+│  ✗ User         compile error                 │
+│    └ line 12: undefined var `nam`             │
+│                                               │
+│ Reloads: 7  Errors: 1  Uptime: 2m 30s        │
+└───────────────────────────────────────────────┘
+```
+
+**Features:**
+- Polls `src/*.winn` every 500ms for changes
+- Hot-reloads changed modules via BEAM code swap (no restart needed)
+- Compile errors keep the last working version loaded
+- Live dashboard with per-module status, reload times, and error details
+- `--start` flag starts OTP apps and calls `main()` before watching
+
+---
+
 ### `winn deps`
 
 Manage project dependencies.


### PR DESCRIPTION
## Summary
- `winn watch` polls source files and hot-reloads modules via BEAM code swap
- **Live terminal dashboard** with Unicode box drawing showing:
  - Per-module status (✓ ok / ✗ error) with time since last reload
  - Compile errors shown inline with source line
  - Total reloads, error count, and uptime
- `winn watch --start` starts OTP apps + calls main() before watching
- Compile errors keep the last working version loaded (no crashes)
- 12 new tests (329 total, 0 failures)

Closes #11

## Test plan
- [x] `rebar3 eunit` — 329 tests, 0 failures
- [x] Dashboard formatting tests (module lines, error lines, stats, title)
- [x] Format helpers (elapsed time, uptime)
- [x] File change detection logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)