### PR TITLE
Fix: allow module names as function arguments

### DIFF
--- a/apps/winn/src/winn_codegen.erl
+++ b/apps/winn/src/winn_codegen.erl
@@ -138,7 +138,7 @@ gen_expr({var, _Line, Name}) ->
 %% Literals
 gen_expr({integer, _Line, V})  -> cerl:c_int(V);
 gen_expr({float,   _Line, V})  -> cerl:c_float(V);
-gen_expr({atom,    _Line, V})  -> cerl:c_atom(V);
+gen_expr({atom,    _Line, V})  -> cerl:c_atom(resolve_atom(V));
 gen_expr({boolean, _Line, V})  -> cerl:c_atom(V);
 gen_expr({nil,     _Line})     -> cerl:c_atom(nil);
 
@@ -331,6 +331,18 @@ winn_module_atom(Name) when is_atom(Name) ->
     list_to_atom(string:lowercase(atom_to_list(Name))).
 
 fn_atom(Name) when is_atom(Name) -> Name.
+
+%% Module name references (PascalCase) used as values are lowercased
+%% to match compiled module names: Post -> post.
+%% Regular atoms (:ok, :error, etc.) are left as-is.
+resolve_atom(V) when is_atom(V) ->
+    Str = atom_to_list(V),
+    case Str of
+        [C | _] when C >= $A, C =< $Z ->
+            list_to_atom(string:lowercase(Str));
+        _ ->
+            V
+    end.
 
 %% Capitalise the first letter of a variable name for Core Erlang convention.
 %% Only lowercase ASCII letters are capitalised; _ and uppercase are left alone.

--- a/apps/winn/src/winn_parser.yrl
+++ b/apps/winn/src/winn_parser.yrl
@@ -160,6 +160,7 @@ unary_expr -> '-' unary_expr
 primary_expr -> call_expr                  : '$1'.
 primary_expr -> block_call                 : '$1'.
 primary_expr -> ident                      : {var, line('$1'), val('$1')}.
+primary_expr -> module_name                : {atom, line('$1'), val('$1')}.
 primary_expr -> ident '.' ident            : {field_access, line('$2'), {var, line('$1'), val('$1')}, val('$3')}.
 primary_expr -> literal                    : '$1'.
 primary_expr -> '(' expr ')'               : '$2'.


### PR DESCRIPTION
## Summary
- Module names (PascalCase like `Post`, `Contact`, `Router`) can now be used as function arguments
- Fixes parse error with `Repo.insert(Post, data)`, `Server.start(Router, 4000)`, etc.
- Module name refs are lowercased in codegen to match compiled module names (`Post` -> `post`)

## Root cause
`module_name` tokens were not valid `primary_expr` in the parser grammar, so they couldn't appear in argument lists.

## Test plan
- [x] `rebar3 eunit` — 360 tests, 0 failures
- [x] `pair(Post, 42)` parses and returns `{post, 42}`
- [x] Module names work in tuples, argument lists, and as standalone expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)