### PR TITLE
Fix: ? in function names and dotted module definitions

### DIFF
--- a/apps/winn/src/winn_lexer.xrl
+++ b/apps/winn/src/winn_lexer.xrl
@@ -87,6 +87,8 @@ preload                     : {token, {'preload', TokenLine}}.
 {UC}{AN}*                   : {token, {module_name, TokenLine, list_to_atom(TokenChars)}}.
 
 %% Lowercase/underscore identifier = variable or local function call
+%% Allows trailing ? for predicate functions (contains?, valid?, etc.)
+{A}{AN}*\?                  : {token, {ident, TokenLine, list_to_atom(TokenChars)}}.
 {A}{AN}*                    : {token, {ident, TokenLine, list_to_atom(TokenChars)}}.
 
 %% Single-character comparison operators

--- a/apps/winn/src/winn_parser.yrl
+++ b/apps/winn/src/winn_parser.yrl
@@ -15,7 +15,7 @@
 Nonterminals
     program
     top_forms top_form
-    module_def module_body
+    module_def module_body dotted_name
     use_directive import_directive alias_directive
     function_def param_list pattern_list
     expr_seq
@@ -67,8 +67,12 @@ top_form -> module_def : '$1'.
 
 %% ── Module ─────────────────────────────────────────────────────────────────
 
-module_def -> 'module' module_name module_body 'end'
-    : {module, line('$1'), val('$2'), '$3'}.
+module_def -> 'module' dotted_name module_body 'end'
+    : {module, line('$1'), '$2', '$3'}.
+
+dotted_name -> module_name                    : val('$1').
+dotted_name -> module_name '.' dotted_name    :
+    list_to_atom(atom_to_list(val('$1')) ++ "." ++ atom_to_list('$3')).
 
 module_body -> '$empty' : [].
 module_body -> function_def module_body : ['$1' | '$2'].


### PR DESCRIPTION
## Summary
1. **? in function names** — `List.contains?`, `Map.has_key?`, `Enum.any?` etc. now lex correctly. Added `{A}{AN}*\?` rule before the plain ident rule.
2. **Dotted module names** — `module MyApp.Router` now parses. Added `dotted_name` nonterminal that joins segments: `MyApp.Router` → atom `'MyApp.Router'`.

## Test plan
- [x] `rebar3 eunit` — 360 tests, 0 failures
- [x] `contains?` lexes as ident token
- [x] `module MyApp.Router` parses as `{module, _, 'MyApp.Router', _}`
- [x] `List.contains?(2, [1,2,3])` compiles and returns `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)