### PR TITLE
Update all documentation for v0.3.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 rebar3 compile              # Compile everything
-rebar3 eunit                # Run all 313 tests
+rebar3 eunit                # Run all 360 tests
 rebar3 eunit --module=winn_l1_tests  # Run a single test module
 rebar3 escriptize           # Build the winn CLI escript
 ./_build/default/bin/winn help       # Verify CLI works
@@ -43,10 +43,12 @@ All AST nodes are tagged tuples: `{Tag, Line, ...fields}`. No records. Key shape
 `winn_transform.erl` runs these passes in sequence:
 
 1. **Use directives** → behaviour attributes + synthetic functions (GenServer gets `start_link/1`)
-2. **Schema defs** → generated `__schema__/1` and `new/1` functions
-3. **All functions case-wrapped** → even simple-var params get wrapped so guarded + non-guarded clauses merge
-4. **Multi-clause merge** → adjacent same-name/arity functions become one function with case clauses
-5. **Expression desugaring** → pipes flattened, match blocks → case, interpolation → `<>` chains, `for` → `Enum.map`
+2. **Import/alias extraction** → builds import list and alias map from directives
+3. **Schema defs** → generated `__schema__/1` and `new/1` functions
+4. **All functions case-wrapped** → even simple-var params get wrapped so guarded + non-guarded clauses merge
+5. **Multi-clause merge** → adjacent same-name/arity functions become one function with case clauses
+6. **Expression desugaring** → pipes flattened, match blocks → case, interpolation → `<>` chains, `for` → `Enum.map`
+7. **Import/alias rewriting** → local calls rewritten to dot calls (import), short module names expanded (alias)
 
 ## Module Name Mapping (Codegen)
 
@@ -65,7 +67,7 @@ To add a new Winn module: create `winn_newmod.erl`, add a `resolve_dot_call` cla
 
 ## Builtin Function Detection
 
-`to_string`, `to_integer`, `to_float`, `to_atom`, and `inspect` are detected in codegen as local calls and routed to `winn_runtime` instead of `cerl:c_apply`.
+`to_string`, `to_integer`, `to_float`, `to_atom`, and `inspect` are detected in codegen as local calls and routed to `winn_runtime`. `assert` and `assert_equal` are routed to `winn_test`.
 
 ## Variable Scoping in Codegen
 
@@ -99,13 +101,16 @@ Use unique module names in each test to avoid beam cache collisions.
 ## Naming Conventions
 
 - Winn module names: PascalCase → compile to lowercase atoms (`HelloWorld` → `helloworld`)
+- Dotted module names: `module MyApp.Router` → atom `'myapp.router'`
+- Module names as values: PascalCase atoms are lowercased in codegen (`Post` → `post`)
+- Function names can end with `?` for predicates (`contains?`, `valid?`)
 - Runtime functions: dotted atoms (`'io.puts'`, `'enum.map'`)
 - Variables: Core Erlang requires uppercase, so codegen capitalizes first char (`x` → `X`)
 - Pattern nodes use `pat_` prefix: `pat_tuple`, `pat_atom`, `pat_var`, `pat_wildcard`
 
 ## CLI (winn_cli.erl)
 
-Commands: `new`, `compile`, `run`, `start`, `console`, `version`, `help`. The `start` command compiles all `src/*.winn`, loads `_build` dep paths, starts OTP apps, calls `main()`, and blocks with `receive` to keep the VM alive. The `run` command reads the module name from the source file (regex on `module Name`), not from the filename.
+Commands: `new`, `compile`, `run`, `start`, `test`, `docs`, `watch`, `console`, `deps`, `version`, `help`. The `start` command compiles all `src/*.winn`, loads `_build` dep paths, starts OTP apps, calls `main()`, and blocks with `receive` to keep the VM alive. The `run` command reads the module name from the source file (regex on `module Name`), not from the filename.
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Winn is a Ruby/Elixir-inspired language that compiles to the BEAM (Erlang VM). I
 - **Crypto** — hashing, HMAC, random bytes, base64
 - **JSON** — `JSON.encode/decode`
 - **Config** — ETS-backed config with `Config.get/put/load`
+- **Testing framework** — `winn test` with `assert`/`assert_equal`, test discovery
+- **Import/alias** — `import Enum` for unqualified calls, `alias MyApp.Auth` for short names
+- **Doc generator** — `winn docs` generates Markdown API docs with Mermaid dependency graphs
+- **File watcher** — `winn watch` with hot code reloading and live terminal dashboard
 - **Clear error messages** — source context, caret pointers, hints
 - **Compiles to BEAM** — runs on the battle-tested Erlang virtual machine
 
@@ -51,7 +55,7 @@ cp _build/default/bin/winn /usr/local/bin/
 
 ```sh
 winn version
-# => winn 0.2.0
+# => winn 0.3.2
 ```
 
 ## Quick Start
@@ -184,9 +188,12 @@ language-winn/
 │   ├── winn_config.erl      # ETS-backed configuration
 │   ├── winn_repo.erl        # ORM database layer
 │   ├── winn_changeset.erl   # changeset validation
-│   ├── winn_cli.erl         # CLI escript (new/compile/run/start/version/help)
+│   ├── winn_test.erl        # testing framework (assert, test runner)
+│   ├── winn_docs.erl        # documentation generator + Mermaid graphs
+│   ├── winn_watch.erl       # file watcher with live terminal dashboard
+│   ├── winn_cli.erl         # CLI escript (new/compile/run/start/test/docs/watch/version/help)
 │   └── winn.erl             # public API
-├── apps/winn/test/           # 294 tests across 22 test files
+├── apps/winn/test/           # 360 tests across 26 test files
 └── docs/
     ├── getting-started.md    # install, create, build, run
     ├── language.md           # syntax reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -447,6 +447,69 @@ If you're using the VS Code extension, errors show as red squigglies inline.
 
 ---
 
+## 14. Testing
+
+Write tests in Winn using `use Winn.Test`:
+
+```winn
+module MathTest
+  use Winn.Test
+
+  def test_addition()
+    assert(1 + 1 == 2)
+  end
+
+  def test_greeting()
+    result = "Hello, " <> "World"
+    assert_equal("Hello, World", result)
+  end
+end
+```
+
+Save as `test/math_test.winn` and run:
+
+```sh
+winn test
+```
+
+Output:
+
+```
+  ✓ mathtest:test_addition
+  ✓ mathtest:test_greeting
+
+2 tests, 0 failures (0ms)
+```
+
+Test functions must be named `test_*` with zero arguments. Use `assert(expr)` for boolean checks and `assert_equal(expected, actual)` for value comparisons.
+
+---
+
+## 15. Generating Documentation
+
+Generate API docs from your source with `winn docs`:
+
+```sh
+winn docs
+# => Generated docs for 3 module(s) in doc/api/
+```
+
+This creates Markdown files in `doc/api/` with function signatures extracted from `#` doc comments, plus a **Mermaid dependency graph** in `index.md` that renders on GitHub.
+
+---
+
+## 16. Watch Mode
+
+Use `winn watch` for automatic recompilation and hot code reloading during development:
+
+```sh
+winn watch --start
+```
+
+This starts your app and shows a live terminal dashboard. When you edit a `.winn` file, the module is recompiled and hot-reloaded without restarting the VM.
+
+---
+
 ## Next Steps
 
 - [Language Guide](language.md) — full syntax reference

--- a/docs/language.md
+++ b/docs/language.md
@@ -18,6 +18,29 @@ end
 
 Module names are capitalized. They compile to lowercase Erlang module atoms (`Greeter` → `:greeter`).
 
+### Dotted Module Names
+
+Modules can use dotted names for hierarchical organization:
+
+```winn
+module MyApp.Router
+  def routes()
+    [{:get, "/", :index}]
+  end
+end
+```
+
+Dotted names compile to dotted atoms (`MyApp.Router` → `:'myapp.router'`).
+
+### Module References as Values
+
+Module names can be passed as values to functions. They compile to lowercase atoms matching the compiled module name:
+
+```winn
+Repo.insert(Post, changeset)    # Post becomes the atom :post
+Repo.all(Contact)               # Contact becomes :contact
+```
+
 ### Import
 
 `import` brings a module's functions into scope as local calls:
@@ -53,6 +76,19 @@ The short name is the last segment: `alias MyApp.Auth` makes `Auth` available.
 ## Functions
 
 Functions are defined with `def` and closed with `end`. The last expression in a function body is the return value.
+
+Function names can end with `?` for predicates:
+
+```winn
+def valid?(changeset)
+  Changeset.valid(changeset)
+end
+
+# Standard library predicates:
+List.contains?(2, [1, 2, 3])    # => true
+Map.has_key?(user, :name)       # => true
+Enum.any?([1, 2, 3]) do |x| x > 2 end  # => true
+```
 
 ```winn
 module Math

--- a/docs/otp.md
+++ b/docs/otp.md
@@ -158,6 +158,28 @@ end
 
 ---
 
+## Test (use Winn.Test)
+
+Define test modules with `use Winn.Test`:
+
+```winn
+module UserTest
+  use Winn.Test
+
+  def test_create()
+    assert(1 + 1 == 2)
+  end
+
+  def test_equality()
+    assert_equal("hello", "hello")
+  end
+end
+```
+
+`use Winn.Test` adds `-behaviour(winn_test)`. Test functions must be named `test_*`. Run with `winn test`. See [CLI Reference](cli.md#winn-test-file) and [Standard Library](stdlib.md#testing) for details.
+
+---
+
 ## Calling OTP Functions
 
 Use `GenServer` and `Supervisor` module calls from Winn:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Winn Roadmap
 
-## Current Status — v0.2.0
+## Current Status — v0.3.2
 
-294 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics.
+360 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics.
 
 ### Completed
 
@@ -12,14 +12,23 @@
 | Language | String interpolation (`"#{expr}"`), standalone lambdas (`fn => end`) | v0.2.0 |
 | Language | For comprehensions, range literals (`1..10`), pattern assignment | v0.2.0 |
 | Language | Map field access (`user.name`), multi-line switch/rescue bodies | v0.2.0 |
+| Language | `import Module`, `alias Parent.Child` | v0.3.0 |
+| Language | Dotted module names (`module MyApp.Router`), `?` in names | v0.3.2 |
+| Language | Module names as expressions (`Repo.insert(Post, data)`) | v0.3.1 |
 | Runtime | System (env vars), UUID, DateTime, Logger, Crypto | v0.1.0 |
 | Runtime | JSON module, type builtins (to_string, to_integer, etc.) | v0.2.0 |
 | Modules | HTTP client (hackney), HTTP server (Cowboy), middleware | v0.2.0 |
 | Modules | Config (ETS), Task/Async, JWT (pure Erlang), WebSockets (gun) | v0.1.0 |
 | OTP | GenServer, Supervisor, Application, Task behaviours | v0.1.0 |
 | ORM | Schema DSL, Changeset, Repo (PostgreSQL via epgsql) | v0.1.0 |
-| Tooling | CLI (new/compile/run/start/version), Homebrew formula | v0.2.0 |
+| Testing | `winn test`, `use Winn.Test`, `assert`/`assert_equal` | v0.3.0 |
+| Tooling | CLI (new/compile/run/start/test/docs/watch/version), Homebrew | v0.3.0 |
 | Tooling | VS Code extension, compiler error messages with source context | v0.2.0 |
+| Tooling | `winn docs` with Mermaid dependency graph | v0.3.0 |
+| Tooling | `winn watch` with live terminal dashboard | v0.3.0 |
+| Tooling | CI (GitHub Actions), CHANGELOG, merge to main | v0.2.0 |
+| Tooling | REPL (`winn console`), dependency management (`winn deps`) | v0.2.0 |
+| Compiler | `module_info/0,1` generated for all compiled modules | v0.3.0 |
 
 ---
 
@@ -493,14 +502,14 @@ N10 (newlines) → N12 (structs) → N13 (protocols) → N5 (import/alias)
 | S1 | HTTP server (Cowboy) + middleware | done |
 | MI1-MI5 | middleware, type builtins, ranges, multi-line bodies, error messages | done |
 | Tooling | CLI (new/compile/run/start/version), Homebrew, VS Code extension | done |
-| N1 | Merge to main, CI, changelog | planned |
-| N2 | REPL (winn shell) | planned |
-| N3 | Package management (winn deps) | planned |
-| N4 | Testing framework (winn test) | planned |
-| N5 | Import and alias | planned |
+| N1 | Merge to main, CI, changelog | **done** (v0.2.0) |
+| N2 | REPL (winn console) | **done** (v0.2.0) |
+| N3 | Package management (winn deps) | **done** (v0.2.0) |
+| N4 | Testing framework (winn test) | **done** (v0.3.0) |
+| N5 | Import and alias | **done** (v0.3.0) |
 | N6 | CLI task runner (winn task) | planned |
-| N7 | Documentation generator (winn docs) | planned |
-| N8 | Hot code reloading (winn watch) | planned |
+| N7 | Documentation generator (winn docs) | **done** (v0.3.0) |
+| N8 | Hot code reloading (winn watch) | **done** (v0.3.0) |
 | N9 | Database migrations | planned |
 | N10 | Significant newlines | planned |
 | N11 | Pipe assign (\|>=) | planned |


### PR DESCRIPTION
## Summary
Comprehensive docs update after v0.3.x releases. 6 files updated:

- **README.md** — version bump, 4 new features listed, project structure updated (360 tests)
- **roadmap.md** — N1-N5/N7-N8 marked done, completed features table expanded
- **language.md** — dotted module names, module refs as values, `?` in function names
- **getting-started.md** — new sections: testing, docs generator, watch mode
- **otp.md** — added `use Winn.Test` section
- **CLAUDE.md** — test count, CLI commands, naming conventions, transform order

🤖 Generated with [Claude Code](https://claude.com/claude-code)