### PR TITLE
Add Repo.configure for Winn-native database config

### DIFF
--- a/apps/winn/src/winn_config.erl
+++ b/apps/winn/src/winn_config.erl
@@ -9,7 +9,7 @@
 %% Backed by ETS for fast concurrent reads.
 
 -module(winn_config).
--export([get/2, get/3, put/3, load/1, init/0]).
+-export([get/2, get/3, put/3, load/1, init/0, ensure_init/0]).
 
 -define(TABLE, winn_config_table).
 

--- a/apps/winn/src/winn_repo.erl
+++ b/apps/winn/src/winn_repo.erl
@@ -1,16 +1,41 @@
 -module(winn_repo).
 -export([
-    insert/2, get/2, get/3, all/1, all/2,
-    delete/1, update/1,
+    configure/1, insert/2, get/2, get/3, all/1, all/2,
+    delete/1, update/1, execute/1, execute/2,
     'query.new'/1, 'query.where'/3, 'query.limit'/2,
     sql_for_insert/2, sql_for_select/2
 ]).
 
+%% Configure the database connection from Winn:
+%%   Repo.configure(%{host: "localhost", database: "my_app", ...})
+configure(Config) when is_map(Config) ->
+    winn_config:ensure_init(),
+    maps:fold(fun(Key, Val, _) ->
+        winn_config:put(repo, Key, Val)
+    end, ok, Config),
+    ok.
+
 db_config() ->
-    application:get_env(winn, repo_config, #{
+    %% Read from Config ETS first, fall back to application env, then defaults.
+    Defaults = #{
         host => "localhost", port => 5432,
         database => "winn_dev", username => "postgres", password => ""
-    }).
+    },
+    AppConfig = case application:get_env(winn, repo_config) of
+        {ok, C} -> C;
+        undefined -> #{}
+    end,
+    EtsConfig = read_ets_config(),
+    maps:merge(maps:merge(Defaults, AppConfig), EtsConfig).
+
+read_ets_config() ->
+    Keys = [host, port, database, username, password],
+    lists:foldl(fun(Key, Acc) ->
+        case winn_config:get(repo, Key) of
+            nil -> Acc;
+            Val -> maps:put(Key, Val, Acc)
+        end
+    end, #{}, Keys).
 
 connect() ->
     #{host := Host, port := Port, database := DB,
@@ -147,6 +172,19 @@ update(#{id := Id} = Struct) ->
                 end
             end)
     end.
+
+%% Raw SQL execution
+execute(SQL) when is_binary(SQL) ->
+    execute(SQL, []).
+
+execute(SQL, Params) when is_binary(SQL), is_list(Params) ->
+    with_conn(fun(Conn) ->
+        case epgsql:equery(Conn, binary_to_list(SQL), Params) of
+            {ok, _Cols, Rows}  -> {ok, Rows};
+            {ok, Count}        -> {ok, Count};
+            {error, Reason}    -> {error, Reason}
+        end
+    end).
 
 with_conn(Fun) ->
     case connect() of

--- a/apps/winn/test/winn_repo_config_tests.erl
+++ b/apps/winn/test/winn_repo_config_tests.erl
@@ -1,0 +1,68 @@
+%% winn_repo_config_tests.erl
+%% Tests for Repo.configure and db_config reading from Config ETS.
+
+-module(winn_repo_config_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Setup/teardown ──────────────────────────────────────────────────────────
+
+setup() ->
+    winn_config:init(),
+    %% Clear any repo config keys
+    lists:foreach(fun(Key) ->
+        winn_config:put(repo, Key, nil)
+    end, [host, port, database, username, password]).
+
+%% ── Repo.configure stores values in Config ETS ─────────────────────────────
+
+configure_sets_values_test() ->
+    setup(),
+    ok = winn_repo:configure(#{
+        host => <<"db.example.com">>,
+        port => 5433,
+        database => <<"my_app">>,
+        username => <<"admin">>,
+        password => <<"secret">>
+    }),
+    ?assertEqual(<<"db.example.com">>, winn_config:get(repo, host)),
+    ?assertEqual(5433, winn_config:get(repo, port)),
+    ?assertEqual(<<"my_app">>, winn_config:get(repo, database)),
+    ?assertEqual(<<"admin">>, winn_config:get(repo, username)),
+    ?assertEqual(<<"secret">>, winn_config:get(repo, password)).
+
+%% ── Partial configure merges with defaults ───────────────────────────────────
+
+partial_configure_test() ->
+    setup(),
+    ok = winn_repo:configure(#{host => <<"custom-host">>}),
+    ?assertEqual(<<"custom-host">>, winn_config:get(repo, host)),
+    %% Unset keys remain nil in ETS (defaults applied at db_config level)
+    ?assertEqual(nil, winn_config:get(repo, port)).
+
+%% ── Multiple configures overwrite ───────────────────────────────────────────
+
+reconfigure_test() ->
+    setup(),
+    ok = winn_repo:configure(#{database => <<"first_db">>}),
+    ok = winn_repo:configure(#{database => <<"second_db">>}),
+    ?assertEqual(<<"second_db">>, winn_config:get(repo, database)).
+
+%% ── End-to-end: Repo.configure from Winn source ────────────────────────────
+
+configure_from_winn_test() ->
+    setup(),
+    Source = "module RepoConfTest\n"
+             "  def run()\n"
+             "    Repo.configure(%{host: \"myhost\", database: \"mydb\"})\n"
+             "  end\n"
+             "end\n",
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ok = ModName:run(),
+    ?assertEqual(<<"myhost">>, winn_config:get(repo, host)),
+    ?assertEqual(<<"mydb">>, winn_config:get(repo, database)).

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -4,17 +4,39 @@ Winn includes a built-in ORM for PostgreSQL backed by [epgsql](https://github.co
 
 ## Configuration
 
-Configure the database connection in your application environment:
+Configure the database connection from Winn using `Repo.configure`:
 
-```erlang
-%% In your Erlang app config or rebar3 shell
-application:set_env(winn, repo_config, #{
-    host     => "localhost",
-    port     => 5432,
-    database => "my_app_dev",
-    username => "postgres",
-    password => "secret"
-}).
+```winn
+module MyApp
+  def main()
+    Repo.configure(%{
+      host: "localhost",
+      port: 5432,
+      database: "my_app_dev",
+      username: "postgres",
+      password: "secret"
+    })
+
+    # Now Repo.insert, Repo.all, etc. use this connection
+  end
+end
+```
+
+Call `Repo.configure` early in your app (e.g., in `main()`) before any database operations. Configuration is stored in the Config ETS table and persists for the lifetime of the VM.
+
+You can also configure individual keys:
+
+```winn
+Repo.configure(%{database: "my_app_test"})
+```
+
+### Raw SQL
+
+Execute raw SQL queries with `Repo.execute`:
+
+```winn
+Repo.execute("CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT)")
+Repo.execute("SELECT * FROM users WHERE age > $1", [18])
 ```
 
 ---


### PR DESCRIPTION
## Summary
- `Repo.configure(%{host: "...", database: "...", ...})` — configure the database from Winn
- `Repo.execute(sql)` / `Repo.execute(sql, params)` — raw SQL queries
- Config stored in Config ETS table, read with fallback: ETS > app env > defaults
- ORM docs updated: replaced Erlang `application:set_env` with Winn `Repo.configure`

## Test plan
- [x] `rebar3 eunit` — 364 tests, 0 failures
- [x] configure/1 stores values in Config ETS
- [x] Partial configure only sets specified keys
- [x] Reconfigure overwrites previous values
- [x] End-to-end: `Repo.configure(...)` compiles and runs from Winn source

🤖 Generated with [Claude Code](https://claude.com/claude-code)