### PR TITLE
Add pipe assign (|>=) and triple-quoted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ All notable changes to the Winn language are documented here.
 ## [Unreleased]
 
 ### Language Features
+- **Pipe assign (`|>=`)** — capture pipe chain results into a variable
+- **Triple-quoted strings (`"""..."""`)** — multi-line strings with auto-dedent and embedded quotes
+
+## [0.3.0] - 2026-03-28
+
+### Language Features
 - **`import Module`** — bring a module's functions into scope as local calls
 - **`alias Parent.Child`** — use a short name for a dotted module path
+- Dotted module names (`module MyApp.Router`), `?` in function names, module names as expressions
 
 ### Testing Framework
 - **`winn test`** — run Winn tests from the CLI
@@ -17,6 +24,8 @@ All notable changes to the Winn language are documented here.
 - **`winn docs`** — generate Markdown API docs with Mermaid dependency graph
 - **`winn watch`** — file watcher with hot code reloading and live terminal dashboard
 - **`winn watch --start`** — watch mode + starts the app
+- **`Repo.configure`** — Winn-native database configuration
+- **`Repo.execute`** — raw SQL queries
 
 ### Compiler
 - **`module_info/0` and `module_info/1`** — now generated for all compiled modules

--- a/apps/winn/src/winn_lexer.xrl
+++ b/apps/winn/src/winn_lexer.xrl
@@ -19,6 +19,7 @@ Rules.
 #[^\n]*                     : skip_token.
 
 %% Two-character operators (must be before single-char operators)
+\|>=                        : {token, {'|>=', TokenLine}}.
 \|>                         : {token, {'|>', TokenLine}}.
 =>                          : {token, {'=>', TokenLine}}.
 ->                          : {token, {'->', TokenLine}}.
@@ -80,6 +81,9 @@ preload                     : {token, {'preload', TokenLine}}.
 %% Integer
 {D}+                        : {token, {integer_lit, TokenLine, list_to_integer(TokenChars)}}.
 
+%% Triple-quoted string (multi-line, can contain unescaped quotes, strips leading whitespace)
+\"\"\"(.|\n)*\"\"\"         : make_triple_string_token(TokenLine, TokenChars).
+
 %% String literal (double-quoted, supports #{expr} interpolation)
 \"[^\"]*\"                  : make_string_token(TokenLine, TokenChars).
 
@@ -119,6 +123,67 @@ preload                     : {token, {'preload', TokenLine}}.
 _                           : {token, {'_', TokenLine}}.
 
 Erlang code.
+
+%% Triple-quoted string constructor — strips common leading whitespace.
+make_triple_string_token(Line, Chars) ->
+    %% Remove the surrounding """ delimiters
+    Inner = lists:sublist(Chars, 4, length(Chars) - 6),
+    %% Strip leading newline if present
+    Stripped = case Inner of
+        [$\n | Rest] -> Rest;
+        Other -> Other
+    end,
+    %% Strip trailing newline + whitespace before closing """
+    Trimmed = strip_trailing_ws(Stripped),
+    %% Strip common leading whitespace
+    Dedented = dedent(Trimmed),
+    case has_interpolation(Dedented) of
+        false ->
+            {token, {string_lit, Line, list_to_binary(Dedented)}};
+        true ->
+            Parts = parse_interp(Dedented, [], []),
+            {token, {interp_string, Line, Parts}}
+    end.
+
+strip_trailing_ws(Str) ->
+    lists:reverse(strip_leading_ws(lists:reverse(Str))).
+
+strip_leading_ws([$\n | Rest]) -> strip_leading_ws(Rest);
+strip_leading_ws([$\s | Rest]) -> strip_leading_ws(Rest);
+strip_leading_ws([$\t | Rest]) -> strip_leading_ws(Rest);
+strip_leading_ws(Other) -> Other.
+
+dedent(Str) ->
+    Lines = split_lines(Str),
+    case Lines of
+        [] -> "";
+        _ ->
+            %% Find minimum indentation of non-empty lines
+            Indents = [count_indent(L) || L <- Lines, L =/= []],
+            MinIndent = case Indents of
+                [] -> 0;
+                _  -> lists:min(Indents)
+            end,
+            Dedented = [drop_chars(L, MinIndent) || L <- Lines],
+            join_lines(Dedented)
+    end.
+
+split_lines(Str) -> split_lines(Str, [], []).
+split_lines([], Cur, Acc) -> lists:reverse([lists:reverse(Cur) | Acc]);
+split_lines([$\n | Rest], Cur, Acc) -> split_lines(Rest, [], [lists:reverse(Cur) | Acc]);
+split_lines([C | Rest], Cur, Acc) -> split_lines(Rest, [C | Cur], Acc).
+
+join_lines([]) -> [];
+join_lines([Single]) -> Single;
+join_lines([H | T]) -> H ++ [$\n | join_lines(T)].
+
+count_indent([$\s | Rest]) -> 1 + count_indent(Rest);
+count_indent([$\t | Rest]) -> 1 + count_indent(Rest);
+count_indent(_) -> 0.
+
+drop_chars(Str, 0) -> Str;
+drop_chars([], _) -> [];
+drop_chars([_ | Rest], N) -> drop_chars(Rest, N - 1).
 
 %% String token constructor — detects interpolation.
 make_string_token(Line, Chars) ->

--- a/apps/winn/src/winn_parser.yrl
+++ b/apps/winn/src/winn_parser.yrl
@@ -44,7 +44,7 @@ Terminals
     'and' 'or' 'not'
     ident module_name
     atom_lit integer_lit float_lit string_lit interp_string boolean_lit
-    '|>' '=>' '..'
+    '|>' '|>=' '=>' '..'
     '<>'
     '==' '!='
     '<=' '>='
@@ -124,6 +124,8 @@ expr -> pipe_expr : '$1'.
 pipe_expr -> or_expr                       : '$1'.
 pipe_expr -> pipe_expr '|>' or_expr
     : {pipe, line('$2'), '$1', '$3'}.
+pipe_expr -> pipe_expr '|>=' ident
+    : {assign, line('$2'), {var, line('$3'), val('$3')}, '$1'}.
 
 or_expr -> and_expr                        : '$1'.
 or_expr -> or_expr 'or' and_expr

--- a/apps/winn/test/winn_v04_tests.erl
+++ b/apps/winn/test/winn_v04_tests.erl
@@ -1,0 +1,80 @@
+%% winn_v04_tests.erl
+%% Tests for v0.4.0 language features: pipe assign, triple-quoted strings.
+
+-module(winn_v04_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_and_load(Source) ->
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% ── Pipe assign (|>=) ───────────────────────────────────────────────────────
+
+pipe_assign_lexer_test() ->
+    {ok, Tokens, _} = winn_lexer:string("x |>= y"),
+    ?assertMatch([{ident,_,x}, {'|>=',_}, {ident,_,y}], Tokens).
+
+pipe_assign_simple_test() ->
+    Mod = compile_and_load(
+        "module PaSimple\n"
+        "  def run()\n"
+        "    [1,2,3] |>= items\n"
+        "    items\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual([1,2,3], Mod:run()).
+
+pipe_assign_in_chain_test() ->
+    Mod = compile_and_load(
+        "module PaChain\n"
+        "  def run()\n"
+        "    [1,2,3,4,5]\n"
+        "      |> Enum.filter() do |x| x > 2 end\n"
+        "      |> Enum.map() do |x| x * 10 end\n"
+        "      |>= results\n"
+        "    results\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual([30,40,50], Mod:run()).
+
+%% ── Triple-quoted strings ───────────────────────────────────────────────────
+
+triple_string_simple_test() ->
+    {ok, Tokens, _} = winn_lexer:string("\"\"\"hello world\"\"\""),
+    ?assertMatch([{string_lit, _, <<"hello world">>}], Tokens).
+
+triple_string_embedded_quotes_test() ->
+    {ok, Tokens, _} = winn_lexer:string("\"\"\"say \"hello\" world\"\"\""),
+    ?assertMatch([{string_lit, _, <<"say \"hello\" world">>}], Tokens).
+
+triple_string_multiline_dedent_test() ->
+    {ok, Tokens, _} = winn_lexer:string("\"\"\"\n  line one\n  line two\n\"\"\""),
+    ?assertMatch([{string_lit, _, <<"line one\nline two">>}], Tokens).
+
+triple_string_compiles_test() ->
+    Mod = compile_and_load(
+        "module TripleComp\n"
+        "  def run()\n"
+        "    \"\"\"\n"
+        "    SELECT *\n"
+        "    FROM users\n"
+        "    \"\"\"\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(<<"SELECT *\nFROM users">>, Mod:run()).
+
+triple_string_interpolation_test() ->
+    Mod = compile_and_load(
+        "module TripleInterp\n"
+        "  def run()\n"
+        "    name = \"Alice\"\n"
+        "    \"\"\"hello #{name}!\"\"\"\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(<<"hello Alice!">>, Mod:run()).

--- a/docs/language.md
+++ b/docs/language.md
@@ -375,6 +375,42 @@ list
   |> Enum.map()    do |x| x * 10 end
 ```
 
+### Pipe Assign (`|>=`)
+
+Capture the result of a pipe chain into a variable:
+
+```winn
+[1, 2, 3, 4, 5]
+  |> Enum.filter() do |x| x > 2 end
+  |> Enum.map() do |x| x * 10 end
+  |>= results
+
+IO.puts("Got #{to_string(List.length(results))} results")
+```
+
+`|>=` assigns the pipe result to the named variable. The variable is available in subsequent expressions.
+
+## Triple-Quoted Strings
+
+Use `"""..."""` for multi-line strings. Common leading whitespace is stripped automatically, and embedded `"` quotes don't need escaping:
+
+```winn
+sql = """
+  SELECT *
+  FROM users
+  WHERE active = true
+  ORDER BY created_at DESC
+"""
+
+html = """
+  <div class="card">
+    <h1>#{title}</h1>
+  </div>
+"""
+```
+
+Triple-quoted strings support interpolation (`#{}`) just like regular strings.
+
 ## Standalone Lambdas
 
 Create anonymous functions with `fn(params) => body end`:


### PR DESCRIPTION
## Summary
- **Pipe assign (`|>=`)** — capture pipe chain results: `list |> Enum.map(...) |>= results`
- **Triple-quoted strings (`"""`)** — multi-line with auto-dedent, embedded quotes, interpolation
- 8 new tests (372 total, 0 failures)

Closes #12, closes #38

## Test plan
- [x] `rebar3 eunit` — 372 tests, 0 failures
- [x] `|>=` lexes, parses, compiles, and scopes correctly in pipe chains
- [x] `"""` handles simple, multi-line, embedded quotes, and interpolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)