### PR TITLE
Add default parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Winn language are documented here.
 ### Language Features
 - **Pipe assign (`|>=`)** — capture pipe chain results into a variable
 - **Triple-quoted strings (`"""..."""`)** — multi-line strings with auto-dedent and embedded quotes
+- **Default parameter values** — `def greet(name, greeting = "Hello")` with multiple arities generated
 
 ## [0.3.0] - 2026-03-28
 

--- a/apps/winn/src/winn_parser.yrl
+++ b/apps/winn/src/winn_parser.yrl
@@ -282,6 +282,10 @@ pattern -> ident
           N   -> {var, line('$1'), N}
       end.
 
+%% Default parameter: name = value (only literals and simple expressions)
+pattern -> ident '=' literal
+    : {default_param, line('$2'), val('$1'), '$3'}.
+
 pattern -> atom_lit
     : {pat_atom, line('$1'), val('$1')}.
 

--- a/apps/winn/src/winn_transform.erl
+++ b/apps/winn/src/winn_transform.erl
@@ -39,8 +39,11 @@ transform_form({module, Line, Name, Body}) ->
     SchemaFns = [transform_function(F)
                  || F <- lists:append([expand_schema_def(SD) || SD <- SchemaDefs])],
 
+    %% Expand default parameters into multiple function clauses.
+    ExpandedFns = lists:flatmap(fun expand_default_params/1, Fns),
+
     %% Transform and merge regular functions.
-    Pass1  = [transform_function(F) || F <- Fns],
+    Pass1  = [transform_function(F) || F <- ExpandedFns],
     Merged = merge_fn_clauses(SchemaFns ++ Pass1),
 
     %% Apply import/alias rewrites.
@@ -103,6 +106,55 @@ expand_use(Line, 'Winn', 'Test', _ModName) ->
     {behaviour_only, Attr};
 expand_use(_Line, 'Winn', 'Schema', _ModName) ->
     {schema_use, none}.
+
+%% ── Default parameter expansion ─────────────────────────────────────────
+%% Generates wrapper clauses for functions with default parameters.
+%% def greet(name, greeting = "Hello") ... end
+%% becomes:
+%%   def greet(name)           → greet(name, "Hello")
+%%   def greet(name, greeting) → <original body>
+
+expand_default_params({function, Line, Name, Params, Body}) ->
+    case split_defaults(Params) of
+        {_, []} ->
+            %% No defaults — return as-is
+            [{function, Line, Name, Params, Body}];
+        {Required, Defaults} ->
+            %% Generate the full-arity clause with plain var params
+            FullParams = Required ++ [begin {var, DL, DN} end
+                                      || {default_param, DL, DN, _} <- Defaults],
+            FullClause = {function, Line, Name, FullParams, Body},
+            %% Generate wrapper clauses for each missing default
+            Wrappers = generate_default_wrappers(Line, Name, Required, Defaults),
+            Wrappers ++ [FullClause]
+    end;
+expand_default_params(Other) ->
+    [Other].
+
+split_defaults(Params) ->
+    split_defaults(Params, [], []).
+split_defaults([], Req, Def) ->
+    {lists:reverse(Req), lists:reverse(Def)};
+split_defaults([{default_param, _, _, _} = D | Rest], Req, Def) ->
+    split_defaults(Rest, Req, [D | Def]);
+split_defaults([P | Rest], Req, Def) ->
+    split_defaults(Rest, [P | Req], Def).
+
+generate_default_wrappers(Line, Name, Required, Defaults) ->
+    %% For N defaults, generate N wrappers.
+    %% Wrapper K takes Required + first K default params, fills in the rest.
+    AllDefaults = [{var, DL, DN} || {default_param, DL, DN, _} <- Defaults],
+    AllDefaultVals = [DV || {default_param, _, _, DV} <- Defaults],
+    NumDefaults = length(Defaults),
+    [begin
+        %% Take first K default params as explicit args
+        ExplicitDefParams = lists:sublist(AllDefaults, K),
+        %% Fill remaining defaults with their values
+        RemainingVals = lists:nthtail(K, AllDefaultVals),
+        WrapperParams = Required ++ ExplicitDefParams,
+        CallArgs = Required ++ ExplicitDefParams ++ RemainingVals,
+        {function, Line, Name, WrapperParams, [{call, Line, Name, CallArgs}]}
+     end || K <- lists:seq(0, NumDefaults - 1)].
 
 %% ── Schema definition expansion ──────────────────────────────────────────
 

--- a/apps/winn/test/winn_default_params_tests.erl
+++ b/apps/winn/test/winn_default_params_tests.erl
@@ -1,0 +1,96 @@
+%% winn_default_params_tests.erl
+%% Tests for default parameter values (#39).
+
+-module(winn_default_params_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_and_load(Source) ->
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% ── Parser ──────────────────────────────────────────────────────────────────
+
+default_param_parses_test() ->
+    Source = "module DpParse\n  def greet(name, g = \"Hi\")\n    g\n  end\nend\n",
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    {ok, [{module, _, _, [{function, _, greet, Params, _}]}]} = winn_parser:parse(Tokens),
+    ?assertMatch([{var, _, name}, {default_param, _, g, {string, _, <<"Hi">>}}], Params).
+
+%% ── Single default ──────────────────────────────────────────────────────────
+
+single_default_with_value_test() ->
+    Mod = compile_and_load(
+        "module DpSingle1\n"
+        "  def greet(name, greeting = \"Hello\")\n"
+        "    greeting <> \", \" <> name\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(<<"Hello, Alice">>, Mod:greet(<<"Alice">>)).
+
+single_default_override_test() ->
+    Mod = compile_and_load(
+        "module DpSingle2\n"
+        "  def greet(name, greeting = \"Hello\")\n"
+        "    greeting <> \", \" <> name\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(<<"Hi, Alice">>, Mod:greet(<<"Alice">>, <<"Hi">>)).
+
+%% ── Multiple defaults ───────────────────────────────────────────────────────
+
+multiple_defaults_none_provided_test() ->
+    Mod = compile_and_load(
+        "module DpMulti1\n"
+        "  def make(name, age = 0, active = true)\n"
+        "    {name, age, active}\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual({<<"Alice">>, 0, true}, Mod:make(<<"Alice">>)).
+
+multiple_defaults_one_provided_test() ->
+    Mod = compile_and_load(
+        "module DpMulti2\n"
+        "  def make(name, age = 0, active = true)\n"
+        "    {name, age, active}\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual({<<"Alice">>, 30, true}, Mod:make(<<"Alice">>, 30)).
+
+multiple_defaults_all_provided_test() ->
+    Mod = compile_and_load(
+        "module DpMulti3\n"
+        "  def make(name, age = 0, active = true)\n"
+        "    {name, age, active}\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual({<<"Alice">>, 30, false}, Mod:make(<<"Alice">>, 30, false)).
+
+%% ── Integer default ─────────────────────────────────────────────────────────
+
+integer_default_test() ->
+    Mod = compile_and_load(
+        "module DpInt\n"
+        "  def add(a, b = 10)\n"
+        "    a + b\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(15, Mod:add(5)),
+    ?assertEqual(8, Mod:add(5, 3)).
+
+%% ── Atom default ────────────────────────────────────────────────────────────
+
+atom_default_test() ->
+    Mod = compile_and_load(
+        "module DpAtom\n"
+        "  def status(val, default = :pending)\n"
+        "    {val, default}\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual({42, pending}, Mod:status(42)),
+    ?assertEqual({42, active}, Mod:status(42, active)).

--- a/docs/language.md
+++ b/docs/language.md
@@ -102,6 +102,33 @@ module Math
 end
 ```
 
+### Default Parameter Values
+
+Parameters can have default values. When called with fewer arguments, defaults are filled in:
+
+```winn
+def greet(name, greeting = "Hello")
+  "#{greeting}, #{name}!"
+end
+
+greet("Alice")          # => "Hello, Alice!"
+greet("Alice", "Hi")    # => "Hi, Alice!"
+```
+
+Multiple defaults are supported — they must come after required parameters:
+
+```winn
+def connect(host, port = 5432, timeout = 5000)
+  # ...
+end
+
+connect("localhost")             # port=5432, timeout=5000
+connect("localhost", 3306)       # timeout=5000
+connect("localhost", 3306, 10000)
+```
+
+Defaults can be strings, integers, floats, atoms, and booleans.
+
 ### Multi-clause Functions
 
 Define multiple clauses for pattern-based dispatch:


### PR DESCRIPTION
## Summary
- `def greet(name, greeting = "Hello")` — parameters with default values
- Multiple defaults supported, must come after required params
- Transform generates wrapper clauses for each missing arity
- 8 new tests (380 total, 0 failures)

Closes #39

## Test plan
- [x] `rebar3 eunit` — 380 tests, 0 failures
- [x] Single default: `greet("Alice")` fills in default
- [x] Multiple defaults: all arity combinations work
- [x] Integer, atom, string, boolean defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)