### PR TITLE
Add struct types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Winn language are documented here.
 - **Pipe assign (`|>=`)** — capture pipe chain results into a variable
 - **Triple-quoted strings (`"""..."""`)** — multi-line strings with auto-dedent and embedded quotes
 - **Default parameter values** — `def greet(name, greeting = "Hello")` with multiple arities generated
+- **Struct types** — `struct [:name, :email]` generates `new/0`, `new/1`, `__struct__/0`, `__fields__/0`
 
 ## [0.3.0] - 2026-03-28
 

--- a/apps/winn/src/winn_lexer.xrl
+++ b/apps/winn/src/winn_lexer.xrl
@@ -33,6 +33,7 @@ Rules.
 %% Keywords — must appear before the identifier catch-all
 module                      : {token, {'module', TokenLine}}.
 def                         : {token, {'def', TokenLine}}.
+struct                      : {token, {'struct', TokenLine}}.
 do                          : {token, {'do', TokenLine}}.
 end                         : {token, {'end', TokenLine}}.
 match                       : {token, {'match', TokenLine}}.

--- a/apps/winn/src/winn_parser.yrl
+++ b/apps/winn/src/winn_parser.yrl
@@ -17,7 +17,7 @@ Nonterminals
     top_forms top_form
     module_def module_body dotted_name
     use_directive import_directive alias_directive
-    function_def param_list pattern_list
+    function_def struct_def struct_fields param_list pattern_list
     expr_seq
     expr
     pipe_expr or_expr and_expr not_expr
@@ -37,7 +37,7 @@ Nonterminals
 
 %% Phase 1 terminals + Phase 2 additions.
 Terminals
-    'module' 'def' 'do' 'end' 'use' 'import' 'alias' 'schema' 'field'
+    'module' 'def' 'struct' 'do' 'end' 'use' 'import' 'alias' 'schema' 'field'
     'match' 'ok_kw' 'err_kw' 'nil_kw'
     'if' 'else' 'switch' 'when' 'try' 'rescue'
     'fn' 'for' 'in'
@@ -80,6 +80,7 @@ module_body -> use_directive module_body : ['$1' | '$2'].
 module_body -> import_directive module_body : ['$1' | '$2'].
 module_body -> alias_directive module_body : ['$1' | '$2'].
 module_body -> schema_def module_body : ['$1' | '$2'].
+module_body -> struct_def module_body : ['$1' | '$2'].
 
 %% ── Use directive ────────────────────────────────────────────────────────────
 
@@ -95,6 +96,16 @@ import_directive -> 'import' module_name
 
 alias_directive -> 'alias' module_name '.' module_name
     : {alias_directive, line('$1'), val('$2'), val('$4')}.
+
+%% ── Struct definition ─────────────────────────────────────────────────────────
+
+struct_def -> 'struct' '[' struct_fields ']'
+    : {struct_def, line('$1'), '$3'}.
+
+struct_fields -> atom_lit
+    : [val('$1')].
+struct_fields -> atom_lit ',' struct_fields
+    : [val('$1') | '$3'].
 
 %% ── Function ───────────────────────────────────────────────────────────────
 

--- a/apps/winn/src/winn_transform.erl
+++ b/apps/winn/src/winn_transform.erl
@@ -27,7 +27,8 @@ transform_form({module, Line, Name, Body}) ->
     {UseDirs, Rest1}    = lists:partition(fun({use_directive,_,_,_}) -> true; (_) -> false end, Body),
     {ImportDirs, Rest2} = lists:partition(fun({import_directive,_,_}) -> true; (_) -> false end, Rest1),
     {AliasDirs, Rest3}  = lists:partition(fun({alias_directive,_,_,_}) -> true; (_) -> false end, Rest2),
-    {SchemaDefs, Fns}   = lists:partition(fun({schema_def,_,_,_})    -> true; (_) -> false end, Rest3),
+    {StructDefs, Rest4} = lists:partition(fun({struct_def,_,_})        -> true; (_) -> false end, Rest3),
+    {SchemaDefs, Fns}   = lists:partition(fun({schema_def,_,_,_})    -> true; (_) -> false end, Rest4),
 
     %% Expand use directives.
     Expanded       = [expand_use(ULine, Mod, Sub, Name) || {use_directive, ULine, Mod, Sub} <- UseDirs],
@@ -35,7 +36,9 @@ transform_form({module, Line, Name, Body}) ->
                   ++ [Attr || {behaviour_only, Attr} <- Expanded],
     SyntheticFns   = [Fn   || {behaviour, _, Fn}   <- Expanded],
 
-    %% Expand schema defs into generated functions, then case-wrap pattern params.
+    %% Expand struct and schema defs into generated functions.
+    StructFns = [transform_function(F)
+                 || F <- lists:append([expand_struct_def(SD, Name) || SD <- StructDefs])],
     SchemaFns = [transform_function(F)
                  || F <- lists:append([expand_schema_def(SD) || SD <- SchemaDefs])],
 
@@ -44,7 +47,7 @@ transform_form({module, Line, Name, Body}) ->
 
     %% Transform and merge regular functions.
     Pass1  = [transform_function(F) || F <- ExpandedFns],
-    Merged = merge_fn_clauses(SchemaFns ++ Pass1),
+    Merged = merge_fn_clauses(StructFns ++ SchemaFns ++ Pass1),
 
     %% Apply import/alias rewrites.
     Imports  = [Mod || {import_directive, _, Mod} <- ImportDirs],
@@ -155,6 +158,41 @@ generate_default_wrappers(Line, Name, Required, Defaults) ->
         CallArgs = Required ++ ExplicitDefParams ++ RemainingVals,
         {function, Line, Name, WrapperParams, [{call, Line, Name, CallArgs}]}
      end || K <- lists:seq(0, NumDefaults - 1)].
+
+%% ── Struct definition expansion ──────────────────────────────────────────
+%% defstruct [:name, :email, :age] generates:
+%%   __struct__()  -> module atom (for type identification)
+%%   __fields__()  -> [:name, :email, :age]
+%%   new()         -> %{__struct__: ModName, name: nil, email: nil, age: nil}
+%%   new(attrs)    -> Map.merge(new(), attrs)
+
+expand_struct_def({struct_def, L, FieldNames}, ModName) ->
+    ModAtom = lower_module_atom(ModName),
+
+    %% __struct__() -> module atom
+    StructFn = {function, L, '__struct__', [],
+                [{atom, L, ModAtom}]},
+
+    %% __fields__() -> list of field atoms
+    FieldsFn = {function, L, '__fields__', [],
+                [{list, L, [{atom, L, F} || F <- FieldNames]}]},
+
+    %% Default map: %{__struct__: mod, field1: nil, field2: nil, ...}
+    DefaultPairs = [{'__struct__', {atom, L, ModAtom}}
+                   | [{F, {nil, L}} || F <- FieldNames]],
+
+    %% new() -> default map
+    New0Fn = {function, L, new, [],
+              [{map, L, DefaultPairs}]},
+
+    %% new(attrs) -> Map.merge(default, attrs)
+    New1Fn = {function, L, new, [{var, L, attrs}],
+              [{dot_call, L, 'Map', merge, [
+                  {map, L, DefaultPairs},
+                  {var, L, attrs}
+              ]}]},
+
+    [StructFn, FieldsFn, New0Fn, New1Fn].
 
 %% ── Schema definition expansion ──────────────────────────────────────────
 

--- a/apps/winn/test/winn_struct_tests.erl
+++ b/apps/winn/test/winn_struct_tests.erl
@@ -1,0 +1,103 @@
+%% winn_struct_tests.erl
+%% Tests for struct types (#13).
+
+-module(winn_struct_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_and_load(Source) ->
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% ── Parser ──────────────────────────────────────────────────────────────────
+
+struct_parses_test() ->
+    Source = "module Pt\n  struct [:name, :age]\nend\n",
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    {ok, [{module, _, 'Pt', Body}]} = winn_parser:parse(Tokens),
+    ?assertMatch([{struct_def, _, [name, age]}], [S || {struct_def, _, _} = S <- Body]).
+
+%% ── new/0 returns defaults ──────────────────────────────────────────────────
+
+struct_new_defaults_test() ->
+    Mod = compile_and_load(
+        "module StNew0\n  struct [:name, :email]\nend\n"),
+    Result = Mod:new(),
+    ?assertEqual(nil, maps:get(name, Result)),
+    ?assertEqual(nil, maps:get(email, Result)),
+    ?assertEqual(stnew0, maps:get('__struct__', Result)).
+
+%% ── new/1 merges attributes ────────────────────────────────────────────────
+
+struct_new_with_attrs_test() ->
+    Mod = compile_and_load(
+        "module StNew1\n  struct [:name, :age]\nend\n"),
+    Result = Mod:new(#{name => <<"Alice">>, age => 30}),
+    ?assertEqual(<<"Alice">>, maps:get(name, Result)),
+    ?assertEqual(30, maps:get(age, Result)),
+    ?assertEqual(stnew1, maps:get('__struct__', Result)).
+
+%% ── __struct__/0 returns module atom ────────────────────────────────────────
+
+struct_type_test() ->
+    Mod = compile_and_load(
+        "module StType\n  struct [:x]\nend\n"),
+    ?assertEqual(sttype, Mod:'__struct__'()).
+
+%% ── __fields__/0 returns field list ─────────────────────────────────────────
+
+struct_fields_test() ->
+    Mod = compile_and_load(
+        "module StFields\n  struct [:a, :b, :c]\nend\n"),
+    ?assertEqual([a, b, c], Mod:'__fields__'()).
+
+%% ── Field access via dot notation ───────────────────────────────────────────
+
+struct_field_access_test() ->
+    Mod = compile_and_load(
+        "module StAccess\n"
+        "  struct [:name, :age]\n"
+        "\n"
+        "  def run()\n"
+        "    user = StAccess.new(%{name: \"Bob\", age: 25})\n"
+        "    {user.name, user.age}\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual({<<"Bob">>, 25}, Mod:run()).
+
+%% ── Struct with functions ───────────────────────────────────────────────────
+
+struct_with_methods_test() ->
+    Mod = compile_and_load(
+        "module StMethod\n"
+        "  struct [:name]\n"
+        "\n"
+        "  def greet(user)\n"
+        "    \"Hello, \" <> user.name\n"
+        "  end\n"
+        "\n"
+        "  def run()\n"
+        "    user = StMethod.new(%{name: \"Alice\"})\n"
+        "    greet(user)\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(<<"Hello, Alice">>, Mod:run()).
+
+%% ── Struct identity via __struct__ key ──────────────────────────────────────
+
+struct_identity_test() ->
+    Mod = compile_and_load(
+        "module StIdent\n"
+        "  struct [:val]\n"
+        "\n"
+        "  def run()\n"
+        "    s = StIdent.new(%{val: 42})\n"
+        "    s.__struct__\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(stident, Mod:run()).

--- a/docs/language.md
+++ b/docs/language.md
@@ -438,6 +438,40 @@ html = """
 
 Triple-quoted strings support interpolation (`#{}`) just like regular strings.
 
+## Structs
+
+Define named struct types with `struct`:
+
+```winn
+module User
+  struct [:name, :email, :age]
+end
+```
+
+This generates:
+- `User.new()` — returns a map with all fields set to `nil` and a `__struct__` key
+- `User.new(%{name: "Alice", age: 30})` — merges attributes into the default map
+- `User.__struct__()` — returns the module atom (for type identification)
+- `User.__fields__()` — returns the list of field names
+
+```winn
+user = User.new(%{name: "Alice", age: 30})
+user.name        # => "Alice"
+user.__struct__  # => :user
+```
+
+Structs are maps with a `__struct__` key, so all Map functions work on them. You can define methods alongside the struct:
+
+```winn
+module User
+  struct [:name, :email]
+
+  def greet(user)
+    "Hello, #{user.name}!"
+  end
+end
+```
+
 ## Standalone Lambdas
 
 Create anonymous functions with `fn(params) => body end`:


### PR DESCRIPTION
## Summary
- `struct [:name, :email, :age]` — named struct types with `__struct__` key for type identity
- Generates `new/0`, `new/1`, `__struct__/0`, `__fields__/0`
- Structs are maps — dot access, Map functions all work
- Methods can be defined alongside struct fields
- 8 new tests (388 total, 0 failures)

Closes #13

## Test plan
- [x] `rebar3 eunit` — 388 tests, 0 failures
- [x] Parser, new/0 defaults, new/1 merge, type identity, field access, methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)