### PR TITLE
Add block comments (#| ... |#)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Winn language are documented here.
 - **Struct types** — `struct [:name, :email]` generates `new/0`, `new/1`, `__struct__/0`, `__fields__/0`
 - **Protocols** — `protocol do ... end` defines interfaces, `impl ProtocolName do ... end` implements them for struct types with runtime ETS dispatch
 - **Significant newlines** — multi-expression switch/rescue clause bodies without `do...end` wrappers (backward compatible)
+- **Block comments** — `#| ... |#` for multi-line comments, can comment out blocks of code
 
 ## [0.3.0] - 2026-03-28
 

--- a/apps/winn/src/winn_lexer.xrl
+++ b/apps/winn/src/winn_lexer.xrl
@@ -16,8 +16,12 @@ Rules.
 {WS}+                       : skip_token.
 \n+                         : {token, {newline, TokenLine}}.
 
-%% Line comments
-#[^\n]*                     : skip_token.
+%% Block comments: #| ... |#
+#\|([^|]|\|[^#])*\|#       : skip_token.
+
+%% Line comments (# not followed by |)
+#[^|\n][^\n]*               : skip_token.
+#                           : skip_token.
 
 %% Two-character operators (must be before single-char operators)
 \|>=                        : {token, {'|>=', TokenLine}}.

--- a/apps/winn/test/winn_block_comment_tests.erl
+++ b/apps/winn/test/winn_block_comment_tests.erl
@@ -1,0 +1,77 @@
+%% winn_block_comment_tests.erl
+%% Tests for block comments (#40).
+
+-module(winn_block_comment_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+lex(Src) ->
+    {ok, Tokens, _} = winn_lexer:string(Src),
+    Tokens.
+
+compile_and_load(Source) ->
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% ── Block comment stripped ──────────────────────────────────────────────────
+
+block_comment_single_line_test() ->
+    ?assertEqual([], lex("#| this is a block comment |#")).
+
+block_comment_multi_line_test() ->
+    ?assertEqual([], lex("#| line one\nline two\nline three |#")).
+
+block_comment_inline_test() ->
+    Tokens = lex("42 #| comment |# 99"),
+    ?assertMatch([{integer_lit, _, 42}, {integer_lit, _, 99}], Tokens).
+
+block_comment_empty_test() ->
+    ?assertEqual([], lex("#||#")).
+
+%% ── Line comments still work ────────────────────────────────────────────────
+
+line_comment_still_works_test() ->
+    Tokens = lex("42 # line comment"),
+    ?assertMatch([{integer_lit, _, 42}], Tokens).
+
+%% ── End-to-end: module with block comments ──────────────────────────────────
+
+block_comment_in_module_test() ->
+    Mod = compile_and_load(
+        "module BcMod\n"
+        "  #|\n"
+        "    This module is just a test.\n"
+        "    It has a block comment.\n"
+        "  |#\n"
+        "\n"
+        "  def run()\n"
+        "    42\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(42, Mod:run()).
+
+block_comment_between_functions_test() ->
+    Mod = compile_and_load(
+        "module BcBetween\n"
+        "  def first()\n"
+        "    1\n"
+        "  end\n"
+        "\n"
+        "  #| second function is commented out\n"
+        "  def second()\n"
+        "    2\n"
+        "  end\n"
+        "  |#\n"
+        "\n"
+        "  def third()\n"
+        "    3\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(1, Mod:first()),
+    ?assertEqual(3, Mod:third()).

--- a/docs/language.md
+++ b/docs/language.md
@@ -784,11 +784,31 @@ Logger.info("request processed", %{duration_ms: 150})
 
 ## Comments
 
-Comments start with `#`:
+Line comments start with `#`:
 
 ```winn
 # This is a comment
 def greet(name)
   IO.puts("Hello, " <> name)  # inline comment
 end
+```
+
+Block comments use `#| ... |#` and can span multiple lines:
+
+```winn
+#|
+  This module handles user authentication.
+  It supports JWT and session-based auth.
+|#
+module Auth
+  def verify(token)
+    # ...
+  end
+end
+```
+
+Block comments can also be used inline or to comment out code:
+
+```winn
+x = 42 #| temporary |# + 0
 ```


### PR DESCRIPTION
## Summary
- `#| ... |#` block comments — multi-line, inline, or for commenting out code blocks
- Line comments (`# ...`) still work as before
- 7 new tests (410 total, 0 failures)

Closes #40

## Test plan
- [x] `rebar3 eunit` — 410 tests, 0 failures
- [x] Single-line, multi-line, inline, empty block comments
- [x] Line comments still work
- [x] Block comments inside modules compile correctly
- [x] Can comment out entire functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)