### PR TITLE
Add CLI task runner (winn task)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Winn language are documented here.
 
+## [Unreleased]
+
+### Tooling
+- **`winn task <name>`** — run project tasks from the CLI (e.g., `winn task db.migrate`)
+
 ## [0.4.0] - 2026-03-29
 
 ### Language Features

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -2,7 +2,7 @@
 %% Escript entry point for the Winn CLI.
 
 -module(winn_cli).
--export([main/1, parse_args/1, scaffold/1]).
+-export([main/1, parse_args/1, scaffold/1, task_name_to_module/1]).
 
 %% ── Entry point ───────────────────────────────────────────────────────────
 
@@ -49,6 +49,9 @@ main(Args) ->
             Opts = #{start => lists:member("--start", WatchArgs)},
             winn_watch:start(Opts);
 
+        {task, TaskArgs} ->
+            run_task(TaskArgs);
+
         {deps, Sub} ->
             Result = run_deps(Sub),
             case Result of
@@ -82,6 +85,7 @@ parse_args(["test" | Args])        -> {test, Args};
 parse_args(["docs"])                -> {docs, []};
 parse_args(["docs" | Args])        -> {docs, Args};
 parse_args(["watch" | Args])       -> {watch, Args};
+parse_args(["task" | Args])        -> {task, Args};
 parse_args(["deps" | Sub])         -> {deps, Sub};
 parse_args(["version" | _])        -> version;
 parse_args(["-v" | _])             -> version;
@@ -396,6 +400,90 @@ load_test_beams(Dir, _Compiled) ->
         end
     end, Beams).
 
+%% ── Task runner ─────────────────────────────────────────────────────────
+
+run_task([]) ->
+    io:format("Usage: winn task <name> [args...]~n~n"
+              "Available tasks are discovered from tasks/*.winn and src/*.winn~n"
+              "modules that use Winn.Task and define a run/1 function.~n~n"
+              "Task names use dots for namespacing:~n"
+              "  winn task db.migrate    => module Tasks.Db.Migrate~n"
+              "  winn task db.seed       => module Tasks.Db.Seed~n"),
+    halt(0);
+run_task([TaskName | Args]) ->
+    %% Compile all source files
+    OutDir = "_build/tasks",
+    ok = filelib:ensure_path(OutDir),
+    SrcFiles = filelib:wildcard("src/*.winn") ++ filelib:wildcard("tasks/*.winn"),
+    case SrcFiles of
+        [] ->
+            io:format("No .winn files found.~n"),
+            halt(1);
+        _ ->
+            lists:foreach(fun(F) ->
+                case winn:compile_file(F, OutDir) of
+                    {ok, _} -> ok;
+                    {error, _} -> ok
+                end
+            end, SrcFiles),
+            code:add_patha(OutDir),
+
+            %% Map task name to module atom
+            %% db.migrate -> tasks.db.migrate (try with tasks. prefix first)
+            %% If not found, try just the dotted name lowercased
+            ModAtom = task_name_to_module(TaskName),
+            case code:ensure_loaded(ModAtom) of
+                {module, ModAtom} ->
+                    case erlang:function_exported(ModAtom, run, 1) of
+                        true ->
+                            try
+                                ModAtom:run(Args),
+                                halt(0)
+                            catch
+                                Class:Reason:Stack ->
+                                    io:format("Task ~s failed: ~p:~p~n~p~n",
+                                              [TaskName, Class, Reason, Stack]),
+                                    halt(1)
+                            end;
+                        false ->
+                            io:format("Error: module ~s does not export run/1~n", [ModAtom]),
+                            halt(1)
+                    end;
+                _ ->
+                    %% Try without tasks. prefix
+                    SimpleAtom = list_to_atom(string:lowercase(
+                        string:replace(TaskName, ".", ".", all))),
+                    case code:ensure_loaded(SimpleAtom) of
+                        {module, SimpleAtom} ->
+                            case erlang:function_exported(SimpleAtom, run, 1) of
+                                true ->
+                                    try
+                                        SimpleAtom:run(Args),
+                                        halt(0)
+                                    catch
+                                        Class:Reason:Stack ->
+                                            io:format("Task ~s failed: ~p:~p~n~p~n",
+                                                      [TaskName, Class, Reason, Stack]),
+                                            halt(1)
+                                    end;
+                                false ->
+                                    io:format("Error: task ~s not found~n", [TaskName]),
+                                    halt(1)
+                            end;
+                        _ ->
+                            io:format("Error: task ~s not found~n~n"
+                                      "Make sure the task module exists in tasks/ or src/~n"
+                                      "and uses Winn.Task with a run/1 function.~n",
+                                      [TaskName]),
+                            halt(1)
+                    end
+            end
+    end.
+
+task_name_to_module(Name) ->
+    %% "db.migrate" -> "tasks.db.migrate" -> atom
+    list_to_atom("tasks." ++ string:lowercase(Name)).
+
 %% ── Docs generator ──────────────────────────────────────────────────────
 
 run_docs(Args) ->
@@ -476,6 +564,7 @@ print_usage() ->
         "  winn docs <file>        Generate docs for a single file~n"
         "  winn watch              Watch files and hot-reload with live dashboard~n"
         "  winn watch --start      Watch + start the app~n"
+        "  winn task <name>        Run a project task (e.g., winn task db.migrate)~n"
         "  winn deps               Manage dependencies~n"
         "  winn console            Interactive console~n"
         "  winn version            Show version~n"

--- a/apps/winn/test/winn_task_runner_tests.erl
+++ b/apps/winn/test/winn_task_runner_tests.erl
@@ -1,0 +1,62 @@
+%% winn_task_runner_tests.erl
+%% Tests for the CLI task runner (#16).
+
+-module(winn_task_runner_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Parse args ──────────────────────────────────────────────────────────────
+
+parse_task_test() ->
+    ?assertEqual({task, ["db.migrate"]}, winn_cli:parse_args(["task", "db.migrate"])).
+
+parse_task_with_args_test() ->
+    ?assertEqual({task, ["db.seed", "--file", "data.csv"]},
+                 winn_cli:parse_args(["task", "db.seed", "--file", "data.csv"])).
+
+parse_task_no_name_test() ->
+    ?assertEqual({task, []}, winn_cli:parse_args(["task"])).
+
+%% ── Task name to module mapping ─────────────────────────────────────────────
+
+task_name_mapping_test() ->
+    ?assertEqual('tasks.db.migrate', winn_cli:task_name_to_module("db.migrate")).
+
+task_name_simple_test() ->
+    ?assertEqual('tasks.hello', winn_cli:task_name_to_module("hello")).
+
+task_name_nested_test() ->
+    ?assertEqual('tasks.db.seed.users', winn_cli:task_name_to_module("db.seed.users")).
+
+%% ── End-to-end: compile and run a Winn task ─────────────────────────────────
+
+task_e2e_test() ->
+    %% Create a task module, compile it, load it, call run/1
+    Source = "module Tasks.Hello\n"
+             "  use Winn.Task\n"
+             "\n"
+             "  def run(args)\n"
+             "    :ok\n"
+             "  end\n"
+             "end\n",
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+
+    %% Module should be 'tasks.hello' (lowercased dotted name)
+    ?assertEqual('tasks.hello', ModName),
+
+    %% Should have run/1 exported
+    ?assert(erlang:function_exported(ModName, run, 1)),
+
+    %% Should have winn_task behaviour
+    Attrs = ModName:module_info(attributes),
+    Behaviours = proplists:get_value(behaviour, Attrs, []),
+    ?assert(lists:member(winn_task, Behaviours)),
+
+    %% Calling run should work
+    ?assertEqual(ok, ModName:run([])).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -260,6 +260,32 @@ The dashboard shows:
 
 ---
 
+### `winn task <name> [args...]`
+
+Run project tasks. Tasks are Winn modules with `use Winn.Task` and a `run/1` function.
+
+```sh
+winn task db.migrate
+winn task db.seed --file data.csv
+winn task routes
+```
+
+Task names use dots for namespacing — `db.migrate` maps to `module Tasks.Db.Migrate`:
+
+```winn
+module Tasks.Db.Migrate
+  use Winn.Task
+
+  def run(args)
+    IO.puts("Running migrations...")
+  end
+end
+```
+
+Tasks are discovered from `tasks/*.winn` and `src/*.winn`. The task runner compiles all source files, finds the matching module, and calls `run/1` with any extra CLI arguments.
+
+---
+
 ### `winn deps`
 
 Manage project dependencies.


### PR DESCRIPTION
## Summary
- `winn task <name>` — run project tasks from the CLI
- Dotted names map to modules: `db.migrate` → `Tasks.Db.Migrate`
- Compiles `src/` + `tasks/` directories, discovers task modules
- Error handling with stack traces on failure
- 7 new tests (417 total, 0 failures)

Closes #16

## Test plan
- [x] `rebar3 eunit` — 417 tests, 0 failures
- [x] Parse args: task name, with args, no name
- [x] Name-to-module mapping: simple, dotted, nested
- [x] End-to-end: compile Winn task module, verify behaviour + run/1

🤖 Generated with [Claude Code](https://claude.com/claude-code)