### PR TITLE
Use Rails-style colon syntax for winn task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Winn language are documented here.
 ## [Unreleased]
 
 ### Tooling
-- **`winn task <name>`** — run project tasks from the CLI (e.g., `winn task db.migrate`)
+- **`winn task <name>`** — run project tasks from the CLI with Rails-style colon syntax (e.g., `winn task db:migrate`)
 
 ## [0.4.0] - 2026-03-29
 

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -406,9 +406,10 @@ run_task([]) ->
     io:format("Usage: winn task <name> [args...]~n~n"
               "Available tasks are discovered from tasks/*.winn and src/*.winn~n"
               "modules that use Winn.Task and define a run/1 function.~n~n"
-              "Task names use dots for namespacing:~n"
-              "  winn task db.migrate    => module Tasks.Db.Migrate~n"
-              "  winn task db.seed       => module Tasks.Db.Seed~n"),
+              "Task names use colons for namespacing (like Rails):~n"
+              "  winn task db:migrate    => module Tasks.Db.Migrate~n"
+              "  winn task db:seed       => module Tasks.Db.Seed~n"
+              "  winn task routes        => module Tasks.Routes~n"),
     halt(0);
 run_task([TaskName | Args]) ->
     %% Compile all source files
@@ -450,9 +451,9 @@ run_task([TaskName | Args]) ->
                             halt(1)
                     end;
                 _ ->
-                    %% Try without tasks. prefix
-                    SimpleAtom = list_to_atom(string:lowercase(
-                        string:replace(TaskName, ".", ".", all))),
+                    %% Try without tasks. prefix (convert colons to dots)
+                    Dotted = lists:flatten(string:replace(TaskName, ":", ".", all)),
+                    SimpleAtom = list_to_atom(string:lowercase(Dotted)),
                     case code:ensure_loaded(SimpleAtom) of
                         {module, SimpleAtom} ->
                             case erlang:function_exported(SimpleAtom, run, 1) of
@@ -481,8 +482,9 @@ run_task([TaskName | Args]) ->
     end.
 
 task_name_to_module(Name) ->
-    %% "db.migrate" -> "tasks.db.migrate" -> atom
-    list_to_atom("tasks." ++ string:lowercase(Name)).
+    %% "db:migrate" -> "tasks.db.migrate" -> atom (Rails-style colon syntax)
+    Dotted = string:replace(Name, ":", ".", all),
+    list_to_atom("tasks." ++ string:lowercase(lists:flatten(Dotted))).
 
 %% ── Docs generator ──────────────────────────────────────────────────────
 
@@ -564,7 +566,7 @@ print_usage() ->
         "  winn docs <file>        Generate docs for a single file~n"
         "  winn watch              Watch files and hot-reload with live dashboard~n"
         "  winn watch --start      Watch + start the app~n"
-        "  winn task <name>        Run a project task (e.g., winn task db.migrate)~n"
+        "  winn task <name>        Run a project task (e.g., winn task db:migrate)~n"
         "  winn deps               Manage dependencies~n"
         "  winn console            Interactive console~n"
         "  winn version            Show version~n"

--- a/apps/winn/test/winn_task_runner_tests.erl
+++ b/apps/winn/test/winn_task_runner_tests.erl
@@ -7,25 +7,25 @@
 %% ── Parse args ──────────────────────────────────────────────────────────────
 
 parse_task_test() ->
-    ?assertEqual({task, ["db.migrate"]}, winn_cli:parse_args(["task", "db.migrate"])).
+    ?assertEqual({task, ["db:migrate"]}, winn_cli:parse_args(["task", "db:migrate"])).
 
 parse_task_with_args_test() ->
-    ?assertEqual({task, ["db.seed", "--file", "data.csv"]},
-                 winn_cli:parse_args(["task", "db.seed", "--file", "data.csv"])).
+    ?assertEqual({task, ["db:seed", "--file", "data.csv"]},
+                 winn_cli:parse_args(["task", "db:seed", "--file", "data.csv"])).
 
 parse_task_no_name_test() ->
     ?assertEqual({task, []}, winn_cli:parse_args(["task"])).
 
-%% ── Task name to module mapping ─────────────────────────────────────────────
+%% ── Task name to module mapping (colon syntax like Rails) ───────────────────
 
-task_name_mapping_test() ->
-    ?assertEqual('tasks.db.migrate', winn_cli:task_name_to_module("db.migrate")).
+task_name_colon_test() ->
+    ?assertEqual('tasks.db.migrate', winn_cli:task_name_to_module("db:migrate")).
 
 task_name_simple_test() ->
     ?assertEqual('tasks.hello', winn_cli:task_name_to_module("hello")).
 
 task_name_nested_test() ->
-    ?assertEqual('tasks.db.seed.users', winn_cli:task_name_to_module("db.seed.users")).
+    ?assertEqual('tasks.db.seed.users', winn_cli:task_name_to_module("db:seed:users")).
 
 %% ── End-to-end: compile and run a Winn task ─────────────────────────────────
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -265,12 +265,12 @@ The dashboard shows:
 Run project tasks. Tasks are Winn modules with `use Winn.Task` and a `run/1` function.
 
 ```sh
-winn task db.migrate
-winn task db.seed --file data.csv
+winn task db:migrate
+winn task db:seed --file data.csv
 winn task routes
 ```
 
-Task names use dots for namespacing — `db.migrate` maps to `module Tasks.Db.Migrate`:
+Task names use colons for namespacing (like Rails) — `db:migrate` maps to `module Tasks.Db.Migrate`:
 
 ```winn
 module Tasks.Db.Migrate


### PR DESCRIPTION
## Summary
- `winn task db:migrate` instead of `winn task db.migrate` (Rails convention)
- Colons converted to dots internally for module resolution
- Tests and docs updated

## Test plan
- [x] `rebar3 eunit` — 417 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)