### PR TITLE
Add Rails-style model query methods (User.all, User.find, User.create)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Winn language are documented here.
 ### Database
 - **Connection pooling** — `Repo.configure(%{pool_size: 10})` starts a GenServer-based connection pool; connections are checked out/in automatically
 - **Transactions** — `Repo.transaction(fn() => ... end)` wraps operations in BEGIN/COMMIT/ROLLBACK
+- **Rails-style model methods** — schema modules auto-generate `all()`, `find(id)`, `find_by(field, value)`, `create(attrs)`, `delete(record)`, `count()`
 
 ### Tooling
 - **`winn task <name>`** — run project tasks from the CLI with Rails-style colon syntax (e.g., `winn task db:migrate`)

--- a/apps/winn/src/winn_repo.erl
+++ b/apps/winn/src/winn_repo.erl
@@ -3,7 +3,7 @@
     configure/1, start_pool/0, pool_status/0,
     insert/2, get/2, get/3, all/1, all/2,
     delete/1, update/1, execute/1, execute/2,
-    transaction/1,
+    transaction/1, count/1,
     'query.new'/1, 'query.where'/3, 'query.limit'/2,
     sql_for_insert/2, sql_for_select/2
 ]).
@@ -158,6 +158,16 @@ all(SchemaMod, Wheres) ->
         case epgsql:equery(Conn, binary_to_list(SQL), Vals) of
             {ok, Cols, Rows} -> {ok, [row_to_map_cols(Cols, R) || R <- Rows]};
             {error, Reason}  -> {error, Reason}
+        end
+    end).
+
+count(SchemaMod) ->
+    Table = SchemaMod:'__schema__'(source),
+    SQL   = iolist_to_binary(["SELECT COUNT(*) FROM ", Table]),
+    with_conn(fun(Conn) ->
+        case epgsql:equery(Conn, binary_to_list(SQL), []) of
+            {ok, _Cols, [{Count}]} -> {ok, Count};
+            {error, Reason}        -> {error, Reason}
         end
     end).
 

--- a/apps/winn/src/winn_transform.erl
+++ b/apps/winn/src/winn_transform.erl
@@ -46,7 +46,7 @@ transform_form({module, Line, Name, Body}) ->
     ImplFns = [transform_function(F)
                || F <- lists:append([expand_impl_def(ID, Name) || ID <- ImplDefs])],
     SchemaFns = [transform_function(F)
-                 || F <- lists:append([expand_schema_def(SD) || SD <- SchemaDefs])],
+                 || F <- lists:append([expand_schema_def(SD, Name) || SD <- SchemaDefs])],
 
     %% Expand default parameters into multiple function clauses.
     ExpandedFns = lists:flatmap(fun expand_default_params/1, Fns),
@@ -267,7 +267,9 @@ expand_impl_def({impl_def, L, ProtocolName, MethodDefs}, ModName) ->
 
 %% ── Schema definition expansion ──────────────────────────────────────────
 
-expand_schema_def({schema_def, L, TableBin, Fields}) ->
+expand_schema_def({schema_def, L, TableBin, Fields}, ModName) ->
+    ModAtom = lower_module_atom(ModName),
+
     %% __schema__(:source) -> table name binary
     SourceFn = {function, L, '__schema__', [{pat_atom, L, source}],
                 [{string, L, TableBin}]},
@@ -288,7 +290,35 @@ expand_schema_def({schema_def, L, TableBin, Fields}) ->
                  {var, L, attrs}
              ]}]},
 
-    [SourceFn, FieldsFn, TypesFn, NewFn].
+    %% ── Rails-style model query methods ─────────────────────────────
+    %% all()         -> Repo.all(ModName)
+    AllFn = {function, L, all, [],
+             [{dot_call, L, 'Repo', all, [{atom, L, ModAtom}]}]},
+
+    %% find(id)      -> Repo.get(ModName, id)
+    FindFn = {function, L, find, [{var, L, id}],
+              [{dot_call, L, 'Repo', get, [{atom, L, ModAtom}, {var, L, id}]}]},
+
+    %% find_by(field, value) -> Repo.get(ModName, field, value)
+    FindByFn = {function, L, find_by, [{var, L, field}, {var, L, value}],
+                [{dot_call, L, 'Repo', get, [
+                    {atom, L, ModAtom}, {var, L, field}, {var, L, value}
+                ]}]},
+
+    %% create(attrs)  -> Repo.insert(ModName, attrs)
+    CreateFn = {function, L, create, [{var, L, attrs}],
+                [{dot_call, L, 'Repo', insert, [{atom, L, ModAtom}, {var, L, attrs}]}]},
+
+    %% delete(record) -> Repo.delete(record)
+    DeleteFn = {function, L, delete, [{var, L, record}],
+                [{dot_call, L, 'Repo', delete, [{var, L, record}]}]},
+
+    %% count()        -> Repo.count(ModName)
+    CountFn = {function, L, count, [],
+               [{dot_call, L, 'Repo', count, [{atom, L, ModAtom}]}]},
+
+    [SourceFn, FieldsFn, TypesFn, NewFn,
+     AllFn, FindFn, FindByFn, CreateFn, DeleteFn, CountFn].
 
 %% ── Function transformation ────────────────────────────────────────────────
 

--- a/apps/winn/test/winn_model_methods_tests.erl
+++ b/apps/winn/test/winn_model_methods_tests.erl
@@ -1,0 +1,120 @@
+%% winn_model_methods_tests.erl
+%% Tests for Rails-style model query methods (#31).
+
+-module(winn_model_methods_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_and_load(Source) ->
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% ── Schema generates model methods ─────────────────────────────────────────
+
+schema_generates_all_test() ->
+    Mod = compile_and_load(
+        "module UserMm\n"
+        "  use Winn.Schema\n"
+        "  schema \"users\" do\n"
+        "    field :name, :string\n"
+        "  end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    ?assert(lists:member({all, 0}, Exports)).
+
+schema_generates_find_test() ->
+    Mod = compile_and_load(
+        "module UserMm2\n"
+        "  use Winn.Schema\n"
+        "  schema \"users\" do\n"
+        "    field :name, :string\n"
+        "  end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    ?assert(lists:member({find, 1}, Exports)).
+
+schema_generates_find_by_test() ->
+    Mod = compile_and_load(
+        "module UserMm3\n"
+        "  use Winn.Schema\n"
+        "  schema \"users\" do\n"
+        "    field :name, :string\n"
+        "  end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    ?assert(lists:member({find_by, 2}, Exports)).
+
+schema_generates_create_test() ->
+    Mod = compile_and_load(
+        "module UserMm4\n"
+        "  use Winn.Schema\n"
+        "  schema \"users\" do\n"
+        "    field :name, :string\n"
+        "  end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    ?assert(lists:member({create, 1}, Exports)).
+
+schema_generates_delete_test() ->
+    Mod = compile_and_load(
+        "module UserMm5\n"
+        "  use Winn.Schema\n"
+        "  schema \"users\" do\n"
+        "    field :name, :string\n"
+        "  end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    ?assert(lists:member({delete, 1}, Exports)).
+
+schema_generates_count_test() ->
+    Mod = compile_and_load(
+        "module UserMm6\n"
+        "  use Winn.Schema\n"
+        "  schema \"users\" do\n"
+        "    field :name, :string\n"
+        "  end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    ?assert(lists:member({count, 0}, Exports)).
+
+%% ── Model methods work alongside custom functions ───────────────────────────
+
+model_with_custom_functions_test() ->
+    Mod = compile_and_load(
+        "module UserMm7\n"
+        "  use Winn.Schema\n"
+        "  schema \"users\" do\n"
+        "    field :name, :string\n"
+        "    field :age, :integer\n"
+        "  end\n"
+        "\n"
+        "  def greet(user)\n"
+        "    \"Hello, \" <> user.name\n"
+        "  end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    %% Both model methods and custom functions exist
+    ?assert(lists:member({all, 0}, Exports)),
+    ?assert(lists:member({find, 1}, Exports)),
+    ?assert(lists:member({create, 1}, Exports)),
+    ?assert(lists:member({greet, 1}, Exports)).
+
+%% ── Schema still generates __schema__ functions ─────────────────────────────
+
+schema_still_has_metadata_test() ->
+    Mod = compile_and_load(
+        "module UserMm8\n"
+        "  use Winn.Schema\n"
+        "  schema \"users\" do\n"
+        "    field :name, :string\n"
+        "    field :email, :string\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(<<"users">>, Mod:'__schema__'(source)),
+    ?assertEqual([name, email], Mod:'__schema__'(fields)).

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -53,6 +53,34 @@ end)
 
 Returns `{:ok, result}` on success. On any error or exception, the transaction is rolled back and returns `{:error, reason}`.
 
+### Model Query Methods
+
+Schema modules automatically get Rails-style query methods:
+
+```winn
+module User
+  use Winn.Schema
+
+  schema "users" do
+    field :name, :string
+    field :email, :string
+    field :age, :integer
+  end
+end
+
+# Query directly on the model — no need to reference Repo
+users = User.all()
+user  = User.find(1)
+user  = User.find_by(:email, "alice@example.com")
+
+{:ok, user} = User.create(%{name: "Alice", email: "alice@example.com"})
+User.delete(user)
+
+count = User.count()
+```
+
+These are generated at compile time — each method is a one-line delegation to the corresponding Repo function. You can still use `Repo.all(User)` directly if you prefer.
+
 You can also configure individual keys:
 
 ```winn


### PR DESCRIPTION
## Summary
- Schema modules auto-generate: `all()`, `find(id)`, `find_by(field, val)`, `create(attrs)`, `delete(record)`, `count()`
- Each method is a compile-time delegation to the corresponding Repo function
- Added `Repo.count/1` for `SELECT COUNT(*)`
- 8 new tests (432 total, 0 failures)

Closes #31

## Test plan
- [x] `rebar3 eunit` — 432 tests, 0 failures
- [x] All 6 model methods exported on schema modules
- [x] Works alongside custom functions
- [x] Schema metadata (__schema__) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)