### PR TITLE
Add code generators (winn create / winn c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Winn language are documented here.
 - **`winn migrate`** — run pending database migrations with `schema_migrations` tracking
 - **`winn rollback`** — rollback migrations with `--step N` support
 - **`winn migrate --status`** — show applied vs pending migrations
+- **`winn create` / `winn c`** — code generators for model, migration, task, router, scaffold
 - **`winn task <name>`** — run project tasks from the CLI with Rails-style colon syntax (e.g., `winn task db:seed`)
 
 ## [0.4.0] - 2026-03-29

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -49,6 +49,9 @@ main(Args) ->
             Opts = #{start => lists:member("--start", WatchArgs)},
             winn_watch:start(Opts);
 
+        {create, CreateArgs} ->
+            run_create(CreateArgs);
+
         {task, TaskArgs} ->
             run_task(TaskArgs);
 
@@ -92,6 +95,8 @@ parse_args(["docs"])                -> {docs, []};
 parse_args(["docs" | Args])        -> {docs, Args};
 parse_args(["watch" | Args])       -> {watch, Args};
 parse_args(["task" | Args])        -> {task, Args};
+parse_args(["create" | Args])      -> {create, Args};
+parse_args(["c" | Args])           -> {create, Args};
 parse_args(["migrate" | Args])     -> {migrate, Args};
 parse_args(["rollback" | Args])    -> {rollback, Args};
 parse_args(["deps" | Sub])         -> {deps, Sub};
@@ -408,6 +413,34 @@ load_test_beams(Dir, _Compiled) ->
         end
     end, Beams).
 
+%% ── Code generators ─────────────────────────────────────────────────────
+
+run_create(["model" | Rest]) when length(Rest) >= 1 ->
+    winn_generator:generate(model, Rest),
+    halt(0);
+run_create(["migration" | Rest]) when length(Rest) >= 1 ->
+    winn_generator:generate(migration, Rest),
+    halt(0);
+run_create(["task" | [Name]]) ->
+    winn_generator:generate(task, [Name]),
+    halt(0);
+run_create(["router" | [Name]]) ->
+    winn_generator:generate(router, [Name]),
+    halt(0);
+run_create(["scaffold" | Rest]) when length(Rest) >= 1 ->
+    winn_generator:generate(scaffold, Rest),
+    halt(0);
+run_create(_) ->
+    io:format("Usage:~n"
+              "  winn create model <Name> [field:type ...]~n"
+              "  winn create migration <Name> [field:type ...]~n"
+              "  winn create task <name>~n"
+              "  winn create router <Name>~n"
+              "  winn create scaffold <Name> [field:type ...]~n"
+              "~n"
+              "Shorthand: winn c model User name:string~n"),
+    halt(0).
+
 %% ── Migration commands ──────────────────────────────────────────────────
 
 run_migrate(["--status"]) ->
@@ -613,6 +646,8 @@ print_usage() ->
         "  winn watch              Watch files and hot-reload with live dashboard~n"
         "  winn watch --start      Watch + start the app~n"
         "  winn task <name>        Run a project task (e.g., winn task db:seed)~n"
+        "  winn create <type>      Generate code (model, migration, task, router, scaffold)~n"
+        "  winn c <type>           Shorthand for winn create~n"
         "  winn migrate            Run pending database migrations~n"
         "  winn rollback           Rollback last database migration~n"
         "  winn deps               Manage dependencies~n"

--- a/apps/winn/src/winn_generator.erl
+++ b/apps/winn/src/winn_generator.erl
@@ -1,0 +1,243 @@
+%% winn_generator.erl
+%% Code generators for models, migrations, tasks, routers, and scaffolds.
+
+-module(winn_generator).
+-export([generate/2, parse_fields/1]).
+
+%% ── Public API ───────────────────────────────────────────────────────────────
+
+generate(model, [Name | FieldArgs]) ->
+    Fields = parse_fields(FieldArgs),
+    ModName = to_pascal(Name),
+    TableName = to_snake(Name) ++ "s",
+    Content = model_template(ModName, TableName, Fields),
+    Path = "src/" ++ to_snake(Name) ++ ".winn",
+    write_file(Path, Content);
+
+generate(migration, [Name | FieldArgs]) ->
+    Fields = parse_fields(FieldArgs),
+    Timestamp = timestamp(),
+    FileName = Timestamp ++ "_" ++ to_snake(Name),
+    Content = migration_template(to_pascal(Name), Fields),
+    Path = "migrations/" ++ FileName ++ ".winn",
+    ok = filelib:ensure_path("migrations"),
+    write_file(Path, Content);
+
+generate(task, [Name]) ->
+    Parts = string:split(Name, ":", all),
+    ModParts = [to_pascal(P) || P <- Parts],
+    ModName = "Tasks." ++ lists:flatten(lists:join(".", ModParts)),
+    FileName = lists:flatten(lists:join("_", Parts)),
+    Content = task_template(ModName),
+    Path = "tasks/" ++ FileName ++ ".winn",
+    ok = filelib:ensure_path("tasks"),
+    write_file(Path, Content);
+
+generate(router, [Name]) ->
+    ModName = to_pascal(Name),
+    Content = router_template(ModName),
+    Path = "src/" ++ to_snake(Name) ++ ".winn",
+    write_file(Path, Content);
+
+generate(scaffold, [Name | FieldArgs]) ->
+    Fields = parse_fields(FieldArgs),
+    %% Generate model
+    generate(model, [Name | FieldArgs]),
+    %% Generate router
+    ModName = to_pascal(Name),
+    RouterContent = scaffold_router_template(ModName, to_snake(Name)),
+    RouterPath = "src/" ++ to_snake(Name) ++ "_router.winn",
+    write_file(RouterPath, RouterContent),
+    %% Generate test
+    TestContent = scaffold_test_template(ModName),
+    TestPath = "test/" ++ to_snake(Name) ++ "_test.winn",
+    ok = filelib:ensure_path("test"),
+    write_file(TestPath, TestContent);
+
+generate(_, _) ->
+    io:format("Unknown generator. Available: model, migration, task, router, scaffold~n"),
+    {error, unknown_generator}.
+
+%% ── Field parsing ────────────────────────────────────────────────────────────
+
+parse_fields(Args) ->
+    lists:filtermap(fun(Arg) ->
+        case string:split(Arg, ":") of
+            [Name, Type] -> {true, {Name, Type}};
+            _ -> false
+        end
+    end, Args).
+
+%% ── Templates ────────────────────────────────────────────────────────────────
+
+model_template(ModName, TableName, Fields) ->
+    FieldAtoms = [":\"" ++ N ++ "\"" || {N, _} <- Fields],
+    StructFields = string:join(FieldAtoms, ", "),
+    SchemaFields = [io_lib:format("    field :~s, :~s~n", [N, T]) || {N, T} <- Fields],
+    lists:flatten(io_lib:format(
+        "module ~s~n"
+        "  use Winn.Schema~n"
+        "~n"
+        "  struct [~s]~n"
+        "~n"
+        "  schema \"~s\" do~n"
+        "~s"
+        "  end~n"
+        "end~n",
+        [ModName, StructFields, TableName, SchemaFields])).
+
+migration_template(Name, Fields) ->
+    case Fields of
+        [] ->
+            lists:flatten(io_lib:format(
+                "module Migrations.~s~n"
+                "  def up()~n"
+                "    Repo.execute(\"-- Add your SQL here\")~n"
+                "  end~n"
+                "~n"
+                "  def down()~n"
+                "    Repo.execute(\"-- Reverse the migration\")~n"
+                "  end~n"
+                "end~n",
+                [Name]));
+        _ ->
+            TableName = guess_table_from_migration(Name),
+            Columns = [io_lib:format("      ~s ~s", [N, sql_type(T)]) || {N, T} <- Fields],
+            ColumnStr = string:join(Columns, ",\n"),
+            lists:flatten(io_lib:format(
+                "module Migrations.~s~n"
+                "  def up()~n"
+                "    Repo.execute(\"CREATE TABLE ~s (~n"
+                "      id SERIAL PRIMARY KEY,~n"
+                "~s,~n"
+                "      created_at TIMESTAMP DEFAULT NOW()~n"
+                "    )\")~n"
+                "  end~n"
+                "~n"
+                "  def down()~n"
+                "    Repo.execute(\"DROP TABLE ~s\")~n"
+                "  end~n"
+                "end~n",
+                [Name, TableName, ColumnStr, TableName]))
+    end.
+
+task_template(ModName) ->
+    lists:flatten(io_lib:format(
+        "module ~s~n"
+        "  use Winn.Task~n"
+        "~n"
+        "  def run(args)~n"
+        "    IO.puts(\"Running task...\")~n"
+        "  end~n"
+        "end~n",
+        [ModName])).
+
+router_template(ModName) ->
+    lists:flatten(io_lib:format(
+        "module ~s~n"
+        "  use Winn.Router~n"
+        "~n"
+        "  def routes()~n"
+        "    [~n"
+        "      {:get, \"/\", :index}~n"
+        "    ]~n"
+        "  end~n"
+        "~n"
+        "  def index(conn)~n"
+        "    Server.json(conn, %{status: \"ok\"})~n"
+        "  end~n"
+        "end~n",
+        [ModName])).
+
+scaffold_router_template(ModName, SnakeName) ->
+    lists:flatten(io_lib:format(
+        "module ~sRouter~n"
+        "  use Winn.Router~n"
+        "~n"
+        "  def routes()~n"
+        "    [~n"
+        "      {:get, \"/~ss\", :index},~n"
+        "      {:get, \"/~ss/:id\", :show},~n"
+        "      {:post, \"/~ss\", :create}~n"
+        "    ]~n"
+        "  end~n"
+        "~n"
+        "  def index(conn)~n"
+        "    {:ok, items} = ~s.all()~n"
+        "    Server.json(conn, items)~n"
+        "  end~n"
+        "~n"
+        "  def show(conn)~n"
+        "    id = Server.path_param(conn, \"id\")~n"
+        "    {:ok, item} = ~s.find(id)~n"
+        "    Server.json(conn, item)~n"
+        "  end~n"
+        "~n"
+        "  def create(conn)~n"
+        "    params = Server.body_params(conn)~n"
+        "    {:ok, item} = ~s.create(params)~n"
+        "    Server.json(conn, item, 201)~n"
+        "  end~n"
+        "end~n",
+        [ModName, SnakeName, SnakeName, SnakeName,
+         ModName, ModName, ModName])).
+
+scaffold_test_template(ModName) ->
+    lists:flatten(io_lib:format(
+        "module ~sTest~n"
+        "  use Winn.Test~n"
+        "~n"
+        "  def test_create()~n"
+        "    assert(true)~n"
+        "  end~n"
+        "~n"
+        "  def test_find()~n"
+        "    assert(true)~n"
+        "  end~n"
+        "end~n",
+        [ModName])).
+
+%% ── Helpers ──────────────────────────────────────────────────────────────────
+
+to_pascal(Name) ->
+    Parts = string:split(Name, "_", all),
+    lists:flatten([capitalize(P) || P <- Parts]).
+
+capitalize([]) -> [];
+capitalize([C | Rest]) when C >= $a, C =< $z -> [C - 32 | Rest];
+capitalize(S) -> S.
+
+to_snake(Name) ->
+    string:lowercase(Name).
+
+timestamp() ->
+    {{Y, M, D}, {H, Mi, S}} = calendar:universal_time(),
+    lists:flatten(io_lib:format("~4..0B~2..0B~2..0B~2..0B~2..0B~2..0B",
+                                [Y, M, D, H, Mi, S])).
+
+guess_table_from_migration(Name) ->
+    %% "CreateUsers" -> "users", "AddEmailToUsers" -> "users"
+    Lower = string:lowercase(Name),
+    case re:run(Lower, "(?:create|add.*to)_?(\\w+)$", [{capture, [1], list}]) of
+        {match, [Table]} -> Table;
+        nomatch -> Lower ++ "s"
+    end.
+
+sql_type("string")   -> "VARCHAR(255)";
+sql_type("text")     -> "TEXT";
+sql_type("integer")  -> "INTEGER";
+sql_type("float")    -> "FLOAT";
+sql_type("boolean")  -> "BOOLEAN";
+sql_type("datetime") -> "TIMESTAMP";
+sql_type(Other)      -> string:uppercase(Other).
+
+write_file(Path, Content) ->
+    case filelib:is_file(Path) of
+        true ->
+            io:format("  exists  ~s~n", [Path]),
+            {error, already_exists};
+        false ->
+            ok = file:write_file(Path, Content),
+            io:format("  create  ~s~n", [Path]),
+            ok
+    end.

--- a/apps/winn/test/winn_generator_tests.erl
+++ b/apps/winn/test/winn_generator_tests.erl
@@ -1,0 +1,131 @@
+%% winn_generator_tests.erl
+%% Tests for code generators (#74).
+
+-module(winn_generator_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── CLI parse args ──────────────────────────────────────────────────────────
+
+parse_create_model_test() ->
+    ?assertEqual({create, ["model", "User", "name:string"]},
+                 winn_cli:parse_args(["create", "model", "User", "name:string"])).
+
+parse_c_shorthand_test() ->
+    ?assertEqual({create, ["model", "User"]},
+                 winn_cli:parse_args(["c", "model", "User"])).
+
+parse_create_scaffold_test() ->
+    ?assertEqual({create, ["scaffold", "Post", "title:string", "body:text"]},
+                 winn_cli:parse_args(["create", "scaffold", "Post", "title:string", "body:text"])).
+
+%% ── Field parsing ───────────────────────────────────────────────────────────
+
+parse_fields_test() ->
+    ?assertEqual([{"name", "string"}, {"age", "integer"}],
+                 winn_generator:parse_fields(["name:string", "age:integer"])).
+
+parse_fields_empty_test() ->
+    ?assertEqual([], winn_generator:parse_fields([])).
+
+parse_fields_invalid_test() ->
+    ?assertEqual([{"name", "string"}],
+                 winn_generator:parse_fields(["name:string", "invalid"])).
+
+%% ── Model generator ────────────────────────────────────────────────────────
+
+model_generates_file_test() ->
+    %% Generate in a temp directory
+    OldDir = file:get_cwd(),
+    TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    file:set_cwd(TmpDir),
+
+    winn_generator:generate(model, ["User", "name:string", "email:string"]),
+
+    {ok, Content} = file:read_file("src/user.winn"),
+    ?assert(binary:match(Content, <<"module User">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"use Winn.Schema">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"schema \"users\"">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"field :name, :string">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"field :email, :string">>) =/= nomatch),
+
+    %% Cleanup
+    file:set_cwd(element(2, OldDir)),
+    os:cmd("rm -rf " ++ TmpDir).
+
+%% ── Task generator ─────────────────────────────────────────────────────────
+
+task_generates_file_test() ->
+    OldDir = file:get_cwd(),
+    TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_path(TmpDir),
+    file:set_cwd(TmpDir),
+
+    winn_generator:generate(task, ["db:seed"]),
+
+    {ok, Content} = file:read_file("tasks/db_seed.winn"),
+    ?assert(binary:match(Content, <<"module Tasks.Db.Seed">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"use Winn.Task">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"def run(args)">>) =/= nomatch),
+
+    file:set_cwd(element(2, OldDir)),
+    os:cmd("rm -rf " ++ TmpDir).
+
+%% ── Router generator ───────────────────────────────────────────────────────
+
+router_generates_file_test() ->
+    OldDir = file:get_cwd(),
+    TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    file:set_cwd(TmpDir),
+
+    winn_generator:generate(router, ["Api"]),
+
+    {ok, Content} = file:read_file("src/api.winn"),
+    ?assert(binary:match(Content, <<"module Api">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"use Winn.Router">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"def routes()">>) =/= nomatch),
+
+    file:set_cwd(element(2, OldDir)),
+    os:cmd("rm -rf " ++ TmpDir).
+
+%% ── Migration generator ────────────────────────────────────────────────────
+
+migration_generates_file_test() ->
+    OldDir = file:get_cwd(),
+    TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_path(TmpDir),
+    file:set_cwd(TmpDir),
+
+    winn_generator:generate(migration, ["CreateUsers", "name:string", "email:string"]),
+
+    Files = filelib:wildcard("migrations/*.winn"),
+    ?assertEqual(1, length(Files)),
+    {ok, Content} = file:read_file(hd(Files)),
+    ?assert(binary:match(Content, <<"module Migrations.CreateUsers">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"def up()">>) =/= nomatch),
+    ?assert(binary:match(Content, <<"CREATE TABLE">>) =/= nomatch),
+
+    file:set_cwd(element(2, OldDir)),
+    os:cmd("rm -rf " ++ TmpDir).
+
+%% ── Scaffold generator ─────────────────────────────────────────────────────
+
+scaffold_generates_files_test() ->
+    OldDir = file:get_cwd(),
+    TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    file:set_cwd(TmpDir),
+
+    winn_generator:generate(scaffold, ["Post", "title:string", "body:text"]),
+
+    ?assert(filelib:is_file("src/post.winn")),
+    ?assert(filelib:is_file("src/post_router.winn")),
+    ?assert(filelib:is_file("test/post_test.winn")),
+
+    {ok, RouterContent} = file:read_file("src/post_router.winn"),
+    ?assert(binary:match(RouterContent, <<"PostRouter">>) =/= nomatch),
+    ?assert(binary:match(RouterContent, <<"Post.all()">>) =/= nomatch),
+
+    file:set_cwd(element(2, OldDir)),
+    os:cmd("rm -rf " ++ TmpDir).


### PR DESCRIPTION
## Summary
- `winn create model User name:string email:string` — struct + schema
- `winn create migration CreateUsers` — timestamped migration with SQL
- `winn create task db:seed` — task module
- `winn create router Api` — router boilerplate
- `winn create scaffold Post title:string body:text` — model + CRUD router + test
- `winn c` shorthand
- 11 new tests (451 total, 0 failures)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)