### PR TITLE
Add extended query builder (order_by, select, count, aggregate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Winn language are documented here.
 - **Connection pooling** — `Repo.configure(%{pool_size: 10})` starts a GenServer-based connection pool; connections are checked out/in automatically
 - **Transactions** — `Repo.transaction(fn() => ... end)` wraps operations in BEGIN/COMMIT/ROLLBACK
 - **Rails-style model methods** — schema modules auto-generate `all()`, `find(id)`, `find_by(field, value)`, `create(attrs)`, `delete(record)`, `count()`
+- **Extended query builder** — `query.order_by`, `query.select`, `query.count`, `Repo.aggregate` (sum/avg/min/max)
 
 ### Tooling
 - **`winn migrate`** — run pending database migrations with `schema_migrations` tracking

--- a/apps/winn/src/winn_repo.erl
+++ b/apps/winn/src/winn_repo.erl
@@ -3,9 +3,11 @@
     configure/1, start_pool/0, pool_status/0,
     insert/2, get/2, get/3, all/1, all/2,
     delete/1, update/1, execute/1, execute/2,
-    transaction/1, count/1,
+    transaction/1, count/1, aggregate/3,
     'query.new'/1, 'query.where'/3, 'query.limit'/2,
-    sql_for_insert/2, sql_for_select/2
+    'query.order_by'/3, 'query.select'/2, 'query.count'/1,
+    sql_for_insert/2, sql_for_select/2,
+    build_where/1
 ]).
 
 %% Configure the database connection from Winn:
@@ -69,7 +71,8 @@ connect() ->
 
 %% Query builder
 'query.new'(SchemaMod) ->
-    #{schema => SchemaMod, wheres => [], limit => all}.
+    #{schema => SchemaMod, wheres => [], limit => all,
+      order_by => none, select => all}.
 
 'query.where'(Query, Field, Value) ->
     Wheres = maps:get(wheres, Query),
@@ -77,6 +80,24 @@ connect() ->
 
 'query.limit'(Query, N) ->
     Query#{limit => N}.
+
+'query.order_by'(Query, Field, Direction) ->
+    Query#{order_by => {Field, Direction}}.
+
+'query.select'(Query, Fields) when is_list(Fields) ->
+    Query#{select => Fields}.
+
+'query.count'(Query) ->
+    #{schema := SchemaMod, wheres := Wheres} = Query,
+    Table = SchemaMod:'__schema__'(source),
+    {WhereSQL, Vals} = build_where(Wheres),
+    SQL = iolist_to_binary(["SELECT COUNT(*) FROM ", Table, WhereSQL]),
+    with_conn(fun(Conn) ->
+        case epgsql:equery(Conn, binary_to_list(SQL), Vals) of
+            {ok, _Cols, [{Count}]} -> {ok, Count};
+            {error, Reason}        -> {error, Reason}
+        end
+    end).
 
 %% SQL generation helpers (usable in tests without a DB)
 sql_for_insert(SchemaMod, Attrs) ->
@@ -152,6 +173,36 @@ all(SchemaMod) ->
         end
     end).
 
+all(SchemaMod, Wheres) when is_map(Wheres), is_map_key(schema, Wheres) ->
+    %% Query map from query builder
+    #{schema := _Mod, wheres := WherePairs} = Wheres,
+    OrderBy = maps:get(order_by, Wheres, none),
+    Limit = maps:get(limit, Wheres, all),
+    SelectFields = maps:get(select, Wheres, all),
+    Table = SchemaMod:'__schema__'(source),
+    {WhereSQL, Vals} = build_where(WherePairs),
+    SelectStr = case SelectFields of
+        all -> <<"*">>;
+        Fields -> iolist_to_binary(lists:join(<<", ">>,
+                    [atom_to_binary(F, utf8) || F <- Fields]))
+    end,
+    OrderSQL = case OrderBy of
+        none -> <<>>;
+        {Field, Dir} ->
+            DirStr = case Dir of asc -> <<"ASC">>; desc -> <<"DESC">>; _ -> <<"ASC">> end,
+            iolist_to_binary([" ORDER BY ", atom_to_binary(Field, utf8), " ", DirStr])
+    end,
+    LimitSQL = case Limit of
+        all -> <<>>;
+        N when is_integer(N) -> iolist_to_binary([" LIMIT ", integer_to_binary(N)])
+    end,
+    SQL = iolist_to_binary(["SELECT ", SelectStr, " FROM ", Table, WhereSQL, OrderSQL, LimitSQL]),
+    with_conn(fun(Conn) ->
+        case epgsql:equery(Conn, binary_to_list(SQL), Vals) of
+            {ok, Cols, Rows} -> {ok, [row_to_map_cols(Cols, R) || R <- Rows]};
+            {error, Reason}  -> {error, Reason}
+        end
+    end);
 all(SchemaMod, Wheres) ->
     {SQL, Vals} = sql_for_select(SchemaMod, Wheres),
     with_conn(fun(Conn) ->
@@ -168,6 +219,20 @@ count(SchemaMod) ->
         case epgsql:equery(Conn, binary_to_list(SQL), []) of
             {ok, _Cols, [{Count}]} -> {ok, Count};
             {error, Reason}        -> {error, Reason}
+        end
+    end).
+
+%% Aggregate: sum, avg, min, max
+aggregate(SchemaMod, Func, Field) when
+        Func =:= sum; Func =:= avg; Func =:= min; Func =:= max ->
+    Table = SchemaMod:'__schema__'(source),
+    FuncStr = string:uppercase(atom_to_list(Func)),
+    ColStr  = atom_to_binary(Field, utf8),
+    SQL = iolist_to_binary(["SELECT ", FuncStr, "(", ColStr, ") FROM ", Table]),
+    with_conn(fun(Conn) ->
+        case epgsql:equery(Conn, binary_to_list(SQL), []) of
+            {ok, _Cols, [{Val}]} -> {ok, Val};
+            {error, Reason}      -> {error, Reason}
         end
     end).
 
@@ -288,3 +353,12 @@ row_to_map_cols(Cols, Row) ->
     ColNames = [binary_to_atom(element(2, C), utf8) || C <- Cols],
     Values   = tuple_to_list(Row),
     maps:from_list(lists:zip(ColNames, Values)).
+
+build_where([]) ->
+    {<<>>, []};
+build_where(WherePairs) ->
+    KVs = lists:reverse(WherePairs),
+    Clauses = [iolist_to_binary([atom_to_binary(F, utf8), " = $", integer_to_binary(I)])
+               || {I, {F, _}} <- lists:zip(lists:seq(1, length(KVs)), KVs)],
+    Vals = [V || {_, V} <- KVs],
+    {iolist_to_binary([" WHERE ", lists:join(<<" AND ">>, Clauses)]), Vals}.

--- a/apps/winn/test/winn_query_builder_tests.erl
+++ b/apps/winn/test/winn_query_builder_tests.erl
@@ -1,0 +1,73 @@
+%% winn_query_builder_tests.erl
+%% Tests for extended query builder (#43).
+
+-module(winn_query_builder_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Repo exports new query functions ────────────────────────────────────────
+
+exports_order_by_test() ->
+    Exports = winn_repo:module_info(exports),
+    ?assert(lists:member({'query.order_by', 3}, Exports)).
+
+exports_select_test() ->
+    Exports = winn_repo:module_info(exports),
+    ?assert(lists:member({'query.select', 2}, Exports)).
+
+exports_query_count_test() ->
+    Exports = winn_repo:module_info(exports),
+    ?assert(lists:member({'query.count', 1}, Exports)).
+
+exports_aggregate_test() ->
+    Exports = winn_repo:module_info(exports),
+    ?assert(lists:member({aggregate, 3}, Exports)).
+
+%% ── Query map building ─────────────────────────────────────────────────────
+
+query_new_test() ->
+    Q = winn_repo:'query.new'(fake_mod),
+    ?assertEqual(fake_mod, maps:get(schema, Q)),
+    ?assertEqual([], maps:get(wheres, Q)),
+    ?assertEqual(all, maps:get(limit, Q)),
+    ?assertEqual(none, maps:get(order_by, Q)),
+    ?assertEqual(all, maps:get(select, Q)).
+
+query_where_test() ->
+    Q = winn_repo:'query.new'(fake_mod),
+    Q2 = winn_repo:'query.where'(Q, name, <<"Alice">>),
+    ?assertEqual([{name, <<"Alice">>}], maps:get(wheres, Q2)).
+
+query_order_by_test() ->
+    Q = winn_repo:'query.new'(fake_mod),
+    Q2 = winn_repo:'query.order_by'(Q, created_at, desc),
+    ?assertEqual({created_at, desc}, maps:get(order_by, Q2)).
+
+query_select_test() ->
+    Q = winn_repo:'query.new'(fake_mod),
+    Q2 = winn_repo:'query.select'(Q, [name, email]),
+    ?assertEqual([name, email], maps:get(select, Q2)).
+
+query_limit_test() ->
+    Q = winn_repo:'query.new'(fake_mod),
+    Q2 = winn_repo:'query.limit'(Q, 10),
+    ?assertEqual(10, maps:get(limit, Q2)).
+
+%% ── Chaining ────────────────────────────────────────────────────────────────
+
+query_chain_test() ->
+    Q = winn_repo:'query.new'(fake_mod),
+    Q2 = winn_repo:'query.where'(Q, active, true),
+    Q3 = winn_repo:'query.order_by'(Q2, name, asc),
+    Q4 = winn_repo:'query.limit'(Q3, 20),
+    Q5 = winn_repo:'query.select'(Q4, [name, email]),
+    ?assertEqual([{active, true}], maps:get(wheres, Q5)),
+    ?assertEqual({name, asc}, maps:get(order_by, Q5)),
+    ?assertEqual(20, maps:get(limit, Q5)),
+    ?assertEqual([name, email], maps:get(select, Q5)).
+
+%% ── build_where helper ──────────────────────────────────────────────────────
+
+build_where_empty_test() ->
+    {SQL, Vals} = winn_repo:build_where([]),
+    ?assertEqual(<<>>, SQL),
+    ?assertEqual([], Vals).


### PR DESCRIPTION
## Summary
- `query.order_by/3`, `query.select/2`, `query.count/1`
- `Repo.aggregate/3` for sum/avg/min/max
- Query maps carry order_by/select/limit, used by `all/2` for full SQL generation
- 11 new tests (462 total, 0 failures)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)