### PR TITLE
Update all documentation for v0.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 rebar3 compile              # Compile everything
-rebar3 eunit                # Run all 360 tests
+rebar3 eunit                # Run all 475 tests
 rebar3 eunit --module=winn_l1_tests  # Run a single test module
 rebar3 escriptize           # Build the winn CLI escript
 ./_build/default/bin/winn help       # Verify CLI works
@@ -110,7 +110,7 @@ Use unique module names in each test to avoid beam cache collisions.
 
 ## CLI (winn_cli.erl)
 
-Commands: `new`, `compile`, `run`, `start`, `test`, `docs`, `watch`, `console`, `deps`, `version`, `help`. The `start` command compiles all `src/*.winn`, loads `_build` dep paths, starts OTP apps, calls `main()`, and blocks with `receive` to keep the VM alive. The `run` command reads the module name from the source file (regex on `module Name`), not from the filename.
+Commands: `new`, `compile`, `run`, `start`, `test`, `docs`, `watch`, `create`/`c`, `task`, `migrate`, `rollback`, `release`, `console`, `deps`, `version`, `help`. The `start` command compiles all `src/*.winn`, loads `_build` dep paths, starts OTP apps, calls `main()`, and blocks with `receive` to keep the VM alive. The `run` command reads the module name from the source file (regex on `module Name`), not from the filename.
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cp _build/default/bin/winn /usr/local/bin/
 
 ```sh
 winn version
-# => winn 0.3.2
+# => winn 0.5.0
 ```
 
 ## Quick Start

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -348,7 +348,7 @@ Print the version.
 
 ```sh
 winn version
-# => winn 0.2.0
+# => winn 0.5.0
 
 # Also works with flags:
 winn -v

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ Requires Erlang/OTP 28+ and rebar3.
 
 ```sh
 winn version
-# => winn 0.2.0
+# => winn 0.5.0
 
 winn help
 ```
@@ -36,7 +36,7 @@ winn help
 You should see:
 
 ```
-Winn 0.2.0 - a compiled language on the BEAM
+Winn 0.5.0 - a compiled language on the BEAM
 
 Usage:
   winn new <name>         Create a new Winn project
@@ -507,6 +507,44 @@ winn watch --start
 ```
 
 This starts your app and shows a live terminal dashboard. When you edit a `.winn` file, the module is recompiled and hot-reloaded without restarting the VM.
+
+---
+
+## 17. Code Generators
+
+Scaffold models, migrations, tasks, and routers:
+
+```sh
+winn create model User name:string email:string
+winn create migration CreateUsers name:string email:string
+winn create task db:seed
+winn create router Api
+winn create scaffold Post title:string body:text
+winn c model User   # shorthand
+```
+
+---
+
+## 18. Database Migrations
+
+Manage your database schema with migrations:
+
+```sh
+winn migrate              # Run all pending migrations
+winn rollback             # Rollback last migration
+winn migrate --status     # Show migration status
+```
+
+---
+
+## 19. Deployment
+
+Build production releases:
+
+```sh
+winn release              # Build a production release
+winn release --docker     # Generate a Dockerfile
+```
 
 ---
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1,6 +1,6 @@
 # Winn ORM
 
-Winn includes a built-in ORM for PostgreSQL backed by [epgsql](https://github.com/epgsql/epgsql).
+Winn includes a built-in ORM supporting PostgreSQL and SQLite. Rails-style model methods, connection pooling, transactions, migrations, and an extensible query builder.
 
 ## Configuration
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Winn Roadmap
 
-## Current Status — v0.3.2
+## Current Status — v0.5.0
 
-360 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics.
+475 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics.
 
 ### Completed
 
@@ -29,6 +29,16 @@
 | Tooling | CI (GitHub Actions), CHANGELOG, merge to main | v0.2.0 |
 | Tooling | REPL (`winn console`), dependency management (`winn deps`) | v0.2.0 |
 | Compiler | `module_info/0,1` generated for all compiled modules | v0.3.0 |
+| Language | Pipe assign (`\|>=`), triple-quoted strings, default params | v0.4.0 |
+| Language | Struct types, protocols with ETS dispatch | v0.4.0 |
+| Language | Significant newlines, block comments (`#\| ... \|#`) | v0.4.0 |
+| Database | Connection pooling, transactions, SQLite adapter | v0.5.0 |
+| Database | Rails-style model methods (`User.all`, `User.find`, `User.create`) | v0.5.0 |
+| Database | Extended query builder (order_by, select, count, aggregate) | v0.5.0 |
+| Database | Migrations (`winn migrate` / `winn rollback`) | v0.5.0 |
+| Tooling | Code generators (`winn create` / `winn c`) | v0.5.0 |
+| Tooling | CLI task runner (`winn task db:seed`) | v0.5.0 |
+| Tooling | Deployment (`winn release` / `winn release --docker`) | v0.5.0 |
 
 ---
 
@@ -507,15 +517,15 @@ N10 (newlines) → N12 (structs) → N13 (protocols) → N5 (import/alias)
 | N3 | Package management (winn deps) | **done** (v0.2.0) |
 | N4 | Testing framework (winn test) | **done** (v0.3.0) |
 | N5 | Import and alias | **done** (v0.3.0) |
-| N6 | CLI task runner (winn task) | planned |
+| N6 | CLI task runner (winn task) | **done** (v0.5.0) |
 | N7 | Documentation generator (winn docs) | **done** (v0.3.0) |
 | N8 | Hot code reloading (winn watch) | **done** (v0.3.0) |
-| N9 | Database migrations | planned |
-| N10 | Significant newlines | planned |
-| N11 | Pipe assign (\|>=) | planned |
-| N12 | Struct types | planned |
-| N13 | Protocols / behaviours | planned |
-| N14 | Deployment (winn release) | planned |
-| E1 | Project website | planned |
+| N9 | Database migrations | **done** (v0.5.0) |
+| N10 | Significant newlines | **done** (v0.4.0) |
+| N11 | Pipe assign (\|>=) | **done** (v0.4.0) |
+| N12 | Struct types | **done** (v0.4.0) |
+| N13 | Protocols / behaviours | **done** (v0.4.0) |
+| N14 | Deployment (winn release) | **done** (v0.5.0) |
+| E1 | Project website | **done** (v0.3.0) |
 | E2 | Example projects | planned |
 | E3 | Package registry | planned |


### PR DESCRIPTION
## Summary
- Version references updated to 0.5.0 across all docs
- roadmap.md: all v0.4.0 and v0.5.0 items marked done
- getting-started.md: new sections for generators, migrations, deployment
- orm.md: mentions SQLite support
- CLAUDE.md: 475 tests, all CLI commands listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)