### PR TITLE
Add metrics module — counters, gauges, histograms, HTTP metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Winn language are documented here.
 
+## [Unreleased]
+
+### Observability
+- **Metrics module** — `Metrics.increment`, `Metrics.set`, `Metrics.observe`, `Metrics.time` for counters, gauges, histograms
+- **HTTP metrics** — `Metrics.record_http` tracks per-endpoint request count, latency percentiles, error rates
+- **BEAM VM stats** — `Metrics.beam_stats()` returns process count, memory, schedulers, uptime
+- **Snapshots** — `Metrics.snapshot()` and `Metrics.http_snapshot()` for reading all metrics
+
 ## [0.5.0] - 2026-04-01
 
 ### Database

--- a/apps/winn/src/winn_codegen.erl
+++ b/apps/winn/src/winn_codegen.erl
@@ -321,6 +321,7 @@ resolve_dot_call('Server', Fun)  -> {winn_server, Fun};
 resolve_dot_call('JSON', Fun)    -> {winn_json, Fun};
 resolve_dot_call('Winn', Fun)    -> {winn_runtime, Fun};
 resolve_dot_call('Protocol', Fun) -> {winn_protocol, Fun};
+resolve_dot_call('Metrics', Fun)  -> {winn_metrics, Fun};
 resolve_dot_call('ReplBindings', get) -> {winn_repl, get_binding};
 resolve_dot_call(Mod, Fun) ->
     ErlMod = list_to_atom(string:lowercase(atom_to_list(Mod))),

--- a/apps/winn/src/winn_metrics.erl
+++ b/apps/winn/src/winn_metrics.erl
@@ -1,0 +1,207 @@
+%% winn_metrics.erl
+%% Built-in metrics collection: counters, gauges, histograms.
+%% ETS-backed for zero-overhead concurrent reads.
+
+-module(winn_metrics).
+-export([enable/0, increment/1, increment/2, set/2,
+         observe/2, time/2,
+         get/1, snapshot/0, reset/1, reset_all/0,
+         http_snapshot/0, record_http/4,
+         beam_stats/0]).
+
+-define(COUNTERS, winn_metrics_counters).
+-define(GAUGES, winn_metrics_gauges).
+-define(HISTOGRAMS, winn_metrics_histograms).
+-define(HTTP, winn_metrics_http).
+-define(HISTOGRAM_SIZE, 1000).
+
+%% ── Initialization ──────────────────────────────────────────────────────────
+
+enable() ->
+    ensure_table(?COUNTERS, set),
+    ensure_table(?GAUGES, set),
+    ensure_table(?HISTOGRAMS, set),
+    ensure_table(?HTTP, set),
+    ok.
+
+ensure_table(Name, Type) ->
+    case ets:whereis(Name) of
+        undefined ->
+            ets:new(Name, [named_table, public, Type, {read_concurrency, true},
+                           {write_concurrency, true}]),
+            ok;
+        _ -> ok
+    end.
+
+%% ── Counters ────────────────────────────────────────────────────────────────
+
+increment(Name) ->
+    increment(Name, 1).
+
+increment(Name, Amount) when is_atom(Name), is_integer(Amount) ->
+    ensure_table(?COUNTERS, set),
+    try
+        ets:update_counter(?COUNTERS, Name, {2, Amount})
+    catch
+        error:badarg ->
+            ets:insert(?COUNTERS, {Name, Amount})
+    end,
+    ok.
+
+%% ── Gauges ──────────────────────────────────────────────────────────────────
+
+set(Name, Value) when is_atom(Name) ->
+    ensure_table(?GAUGES, set),
+    ets:insert(?GAUGES, {Name, Value}),
+    ok.
+
+%% ── Histograms ──────────────────────────────────────────────────────────────
+
+observe(Name, Value) when is_atom(Name), is_number(Value) ->
+    ensure_table(?HISTOGRAMS, set),
+    case ets:lookup(?HISTOGRAMS, Name) of
+        [{Name, Values}] when length(Values) >= ?HISTOGRAM_SIZE ->
+            %% Circular buffer: drop oldest, add newest
+            ets:insert(?HISTOGRAMS, {Name, tl(Values) ++ [Value]});
+        [{Name, Values}] ->
+            ets:insert(?HISTOGRAMS, {Name, Values ++ [Value]});
+        [] ->
+            ets:insert(?HISTOGRAMS, {Name, [Value]})
+    end,
+    ok.
+
+%% ── Timer (convenience) ────────────────────────────────────────────────────
+
+time(Name, Fun) when is_atom(Name), is_function(Fun, 0) ->
+    Start = erlang:monotonic_time(microsecond),
+    Result = Fun(),
+    Elapsed = (erlang:monotonic_time(microsecond) - Start) / 1000, %% ms
+    observe(Name, Elapsed),
+    Result.
+
+%% ── HTTP Metrics ────────────────────────────────────────────────────────────
+%% Called by middleware to record request metrics.
+
+record_http(Method, Path, StatusCode, LatencyMs) ->
+    ensure_table(?HTTP, set),
+    Key = iolist_to_binary([Method, " ", Path]),
+    case ets:lookup(?HTTP, Key) of
+        [{Key, Data}] ->
+            Count = maps:get(count, Data, 0) + 1,
+            Errors = case StatusCode >= 500 of
+                true  -> maps:get(errors, Data, 0) + 1;
+                false -> maps:get(errors, Data, 0)
+            end,
+            TotalMs = maps:get(total_ms, Data, 0) + LatencyMs,
+            Latencies = maps:get(latencies, Data, []),
+            NewLatencies = case length(Latencies) >= ?HISTOGRAM_SIZE of
+                true  -> tl(Latencies) ++ [LatencyMs];
+                false -> Latencies ++ [LatencyMs]
+            end,
+            ets:insert(?HTTP, {Key, #{count => Count, errors => Errors,
+                                      total_ms => TotalMs, latencies => NewLatencies}});
+        [] ->
+            ets:insert(?HTTP, {Key, #{count => 1, errors => 0,
+                                      total_ms => LatencyMs, latencies => [LatencyMs]}})
+    end,
+    ok.
+
+http_snapshot() ->
+    ensure_table(?HTTP, set),
+    Entries = ets:tab2list(?HTTP),
+    maps:from_list([{Key, summarize_http(Data)} || {Key, Data} <- Entries]).
+
+summarize_http(#{count := Count, errors := Errors, total_ms := TotalMs, latencies := Latencies}) ->
+    Sorted = lists:sort(Latencies),
+    Len = length(Sorted),
+    #{count => Count,
+      errors => Errors,
+      avg_ms => case Count of 0 -> 0; _ -> round(TotalMs / Count) end,
+      p50_ms => percentile(Sorted, Len, 50),
+      p95_ms => percentile(Sorted, Len, 95),
+      p99_ms => percentile(Sorted, Len, 99)}.
+
+%% ── Reading Metrics ─────────────────────────────────────────────────────────
+
+get(Name) when is_atom(Name) ->
+    case ets:whereis(?COUNTERS) of
+        undefined -> 0;
+        _ ->
+            case ets:lookup(?COUNTERS, Name) of
+                [{_, V}] -> V;
+                [] ->
+                    case ets:whereis(?GAUGES) of
+                        undefined -> 0;
+                        _ ->
+                            case ets:lookup(?GAUGES, Name) of
+                                [{_, V}] -> V;
+                                [] -> 0
+                            end
+                    end
+            end
+    end.
+
+snapshot() ->
+    Counters = case ets:whereis(?COUNTERS) of
+        undefined -> #{};
+        _ -> maps:from_list(ets:tab2list(?COUNTERS))
+    end,
+    Gauges = case ets:whereis(?GAUGES) of
+        undefined -> #{};
+        _ -> maps:from_list(ets:tab2list(?GAUGES))
+    end,
+    Histograms = case ets:whereis(?HISTOGRAMS) of
+        undefined -> #{};
+        _ -> maps:from_list([{K, summarize_histogram(V)} || {K, V} <- ets:tab2list(?HISTOGRAMS)])
+    end,
+    #{counters => Counters, gauges => Gauges, histograms => Histograms}.
+
+summarize_histogram(Values) ->
+    Sorted = lists:sort(Values),
+    Len = length(Sorted),
+    #{count => Len,
+      avg => case Len of 0 -> 0; _ -> lists:sum(Sorted) / Len end,
+      min => case Sorted of [] -> 0; _ -> hd(Sorted) end,
+      max => case Sorted of [] -> 0; _ -> lists:last(Sorted) end,
+      p50 => percentile(Sorted, Len, 50),
+      p95 => percentile(Sorted, Len, 95),
+      p99 => percentile(Sorted, Len, 99)}.
+
+%% ── Reset ───────────────────────────────────────────────────────────────────
+
+reset(Name) ->
+    lists:foreach(fun(Tab) ->
+        case ets:whereis(Tab) of
+            undefined -> ok;
+            _ -> ets:delete(Tab, Name)
+        end
+    end, [?COUNTERS, ?GAUGES, ?HISTOGRAMS, ?HTTP]).
+
+reset_all() ->
+    lists:foreach(fun(Tab) ->
+        case ets:whereis(Tab) of
+            undefined -> ok;
+            _ -> ets:delete_all_objects(Tab)
+        end
+    end, [?COUNTERS, ?GAUGES, ?HISTOGRAMS, ?HTTP]).
+
+%% ── BEAM VM Stats ───────────────────────────────────────────────────────────
+
+beam_stats() ->
+    #{process_count => erlang:system_info(process_count),
+      process_limit => erlang:system_info(process_limit),
+      memory_total => erlang:memory(total),
+      memory_processes => erlang:memory(processes),
+      memory_binary => erlang:memory(binary),
+      memory_ets => erlang:memory(ets),
+      atom_count => erlang:system_info(atom_count),
+      atom_limit => erlang:system_info(atom_limit),
+      scheduler_count => erlang:system_info(schedulers),
+      uptime_ms => erlang:monotonic_time(millisecond) - erlang:system_info(start_time)}.
+
+%% ── Internal ────────────────────────────────────────────────────────────────
+
+percentile(_, 0, _) -> 0;
+percentile(Sorted, Len, P) ->
+    Index = max(1, min(Len, round(P / 100 * Len))),
+    lists:nth(Index, Sorted).

--- a/apps/winn/test/winn_metrics_tests.erl
+++ b/apps/winn/test/winn_metrics_tests.erl
@@ -1,0 +1,135 @@
+%% winn_metrics_tests.erl
+%% Tests for the metrics module (#36).
+
+-module(winn_metrics_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+setup() ->
+    winn_metrics:enable(),
+    winn_metrics:reset_all().
+
+%% ── Counters ────────────────────────────────────────────────────────────────
+
+counter_increment_test() ->
+    setup(),
+    winn_metrics:increment(requests),
+    winn_metrics:increment(requests),
+    winn_metrics:increment(requests),
+    ?assertEqual(3, winn_metrics:get(requests)).
+
+counter_increment_by_test() ->
+    setup(),
+    winn_metrics:increment(bytes, 100),
+    winn_metrics:increment(bytes, 250),
+    ?assertEqual(350, winn_metrics:get(bytes)).
+
+%% ── Gauges ──────────────────────────────────────────────────────────────────
+
+gauge_set_test() ->
+    setup(),
+    winn_metrics:set(queue_depth, 42),
+    ?assertEqual(42, winn_metrics:get(queue_depth)).
+
+gauge_overwrite_test() ->
+    setup(),
+    winn_metrics:set(active, 10),
+    winn_metrics:set(active, 25),
+    ?assertEqual(25, winn_metrics:get(active)).
+
+%% ── Histograms ──────────────────────────────────────────────────────────────
+
+histogram_observe_test() ->
+    setup(),
+    winn_metrics:observe(latency, 10),
+    winn_metrics:observe(latency, 20),
+    winn_metrics:observe(latency, 30),
+    #{histograms := Histograms} = winn_metrics:snapshot(),
+    #{latency := Stats} = Histograms,
+    ?assertEqual(3, maps:get(count, Stats)),
+    ?assertEqual(10, maps:get(min, Stats)),
+    ?assertEqual(30, maps:get(max, Stats)).
+
+%% ── Timer ───────────────────────────────────────────────────────────────────
+
+timer_test() ->
+    setup(),
+    Result = winn_metrics:time(db_query, fun() ->
+        timer:sleep(5),
+        42
+    end),
+    ?assertEqual(42, Result),
+    #{histograms := Histograms} = winn_metrics:snapshot(),
+    #{db_query := Stats} = Histograms,
+    ?assertEqual(1, maps:get(count, Stats)),
+    ?assert(maps:get(avg, Stats) >= 4). %% at least 4ms
+
+%% ── HTTP Metrics ────────────────────────────────────────────────────────────
+
+http_record_test() ->
+    setup(),
+    winn_metrics:record_http(<<"GET">>, <<"/api/users">>, 200, 12),
+    winn_metrics:record_http(<<"GET">>, <<"/api/users">>, 200, 18),
+    winn_metrics:record_http(<<"GET">>, <<"/api/users">>, 500, 45),
+    Snap = winn_metrics:http_snapshot(),
+    #{<<"GET /api/users">> := Stats} = Snap,
+    ?assertEqual(3, maps:get(count, Stats)),
+    ?assertEqual(1, maps:get(errors, Stats)),
+    ?assertEqual(25, maps:get(avg_ms, Stats)).
+
+%% ── Snapshot ────────────────────────────────────────────────────────────────
+
+snapshot_test() ->
+    setup(),
+    winn_metrics:increment(req_count, 5),
+    winn_metrics:set(conn_active, 3),
+    #{counters := Counters, gauges := Gauges} = winn_metrics:snapshot(),
+    ?assertEqual(5, maps:get(req_count, Counters)),
+    ?assertEqual(3, maps:get(conn_active, Gauges)).
+
+%% ── BEAM Stats ──────────────────────────────────────────────────────────────
+
+beam_stats_test() ->
+    Stats = winn_metrics:beam_stats(),
+    ?assert(maps:get(process_count, Stats) > 0),
+    ?assert(maps:get(memory_total, Stats) > 0),
+    ?assert(maps:get(scheduler_count, Stats) > 0).
+
+%% ── Reset ───────────────────────────────────────────────────────────────────
+
+reset_test() ->
+    setup(),
+    winn_metrics:increment(temp, 10),
+    winn_metrics:reset(temp),
+    ?assertEqual(0, winn_metrics:get(temp)).
+
+reset_all_test() ->
+    setup(),
+    winn_metrics:increment(a, 1),
+    winn_metrics:set(b, 2),
+    winn_metrics:reset_all(),
+    ?assertEqual(0, winn_metrics:get(a)),
+    ?assertEqual(0, winn_metrics:get(b)).
+
+%% ── End-to-end: Metrics from Winn source ───────────────────────────────────
+
+metrics_from_winn_test() ->
+    setup(),
+    Source = "module MetricsTest\n"
+             "  def run()\n"
+             "    Metrics.enable()\n"
+             "    Metrics.increment(:api_calls)\n"
+             "    Metrics.increment(:api_calls)\n"
+             "    Metrics.set(:active_users, 42)\n"
+             "    Metrics.get(:api_calls)\n"
+             "  end\n"
+             "end\n",
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST} = winn_parser:parse(Tokens),
+    Transformed = winn_transform:transform(AST),
+    [CoreMod] = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    Result = ModName:run(),
+    ?assertEqual(2, Result).


### PR DESCRIPTION
## Summary
- Counters: `Metrics.increment(:name)`
- Gauges: `Metrics.set(:name, value)`
- Histograms: `Metrics.observe(:name, value)` with P50/P95/P99
- Timer: `Metrics.time(:name, fn)` wraps function with timing
- HTTP: `Metrics.record_http(method, path, status, latency_ms)` per-endpoint stats
- BEAM: `Metrics.beam_stats()` — process count, memory, schedulers, uptime
- Snapshots: `Metrics.snapshot()`, `Metrics.http_snapshot()`
- 12 new tests (487 total, 0 failures)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)