### PR TITLE
Add live metrics dashboard (winn metrics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Winn language are documented here.
 - **HTTP metrics** — `Metrics.record_http` tracks per-endpoint request count, latency percentiles, error rates
 - **BEAM VM stats** — `Metrics.beam_stats()` returns process count, memory, schedulers, uptime
 - **Snapshots** — `Metrics.snapshot()` and `Metrics.http_snapshot()` for reading all metrics
+- **`winn metrics`** — live terminal dashboard showing HTTP stats, BEAM health, custom metrics
 
 ## [0.5.0] - 2026-04-01
 

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -55,6 +55,9 @@ main(Args) ->
         {task, TaskArgs} ->
             run_task(TaskArgs);
 
+        {metrics, MetricsArgs} ->
+            winn_metrics_dashboard:start(#{args => MetricsArgs});
+
         {release, ReleaseArgs} ->
             run_release(ReleaseArgs);
 
@@ -100,6 +103,7 @@ parse_args(["watch" | Args])       -> {watch, Args};
 parse_args(["task" | Args])        -> {task, Args};
 parse_args(["create" | Args])      -> {create, Args};
 parse_args(["c" | Args])           -> {create, Args};
+parse_args(["metrics" | Args])     -> {metrics, Args};
 parse_args(["release" | Args])     -> {release, Args};
 parse_args(["migrate" | Args])     -> {migrate, Args};
 parse_args(["rollback" | Args])    -> {rollback, Args};
@@ -710,6 +714,7 @@ print_usage() ->
         "  winn watch              Watch files and hot-reload with live dashboard~n"
         "  winn watch --start      Watch + start the app~n"
         "  winn task <name>        Run a project task (e.g., winn task db:seed)~n"
+        "  winn metrics            Live metrics dashboard~n"
         "  winn release            Build a production release~n"
         "  winn release --docker   Generate a Dockerfile~n"
         "  winn create <type>      Generate code (model, migration, task, router, scaffold)~n"

--- a/apps/winn/src/winn_metrics_dashboard.erl
+++ b/apps/winn/src/winn_metrics_dashboard.erl
@@ -1,0 +1,144 @@
+%% winn_metrics_dashboard.erl
+%% Live terminal dashboard for metrics — like winn watch but for observability.
+
+-module(winn_metrics_dashboard).
+-export([start/1, format_dashboard/1]).
+
+-define(REFRESH_INTERVAL, 1000).
+
+%% ── Public API ───────────────────────────────────────────────────────────────
+
+start(Opts) ->
+    winn_metrics:enable(),
+    StartTime = erlang:monotonic_time(second),
+    io:format("\e[2J\e[H"),
+    State = #{start_time => StartTime, prev_snapshot => nil, opts => Opts},
+    loop(State).
+
+%% ── Main loop ───────────────────────────────────────────────────────────────
+
+loop(State) ->
+    Snapshot = winn_metrics:snapshot(),
+    HttpSnap = winn_metrics:http_snapshot(),
+    BeamStats = winn_metrics:beam_stats(),
+    StartTime = maps:get(start_time, State),
+    Now = erlang:monotonic_time(second),
+    Uptime = Now - StartTime,
+
+    DashState = #{
+        snapshot => Snapshot,
+        http => HttpSnap,
+        beam => BeamStats,
+        uptime => Uptime,
+        prev_snapshot => maps:get(prev_snapshot, State, nil)
+    },
+
+    Output = format_dashboard(DashState),
+    io:format("\e[H~ts", [Output]),
+
+    timer:sleep(?REFRESH_INTERVAL),
+    loop(State#{prev_snapshot => Snapshot}).
+
+%% ── Dashboard rendering ─────────────────────────────────────────────────────
+
+format_dashboard(#{snapshot := Snap, http := HttpSnap, beam := Beam, uptime := Uptime}) ->
+    Width = 60,
+    #{counters := Counters, gauges := Gauges} = Snap,
+
+    %% Header
+    Title = " Winn Metrics ",
+    PadLen = Width - length(Title) - 2,
+    Header = io_lib:format("\e[1m~ts~ts~ts~ts\e[0m~n",
+        [[$\x{250C}, $\x{2500}], Title,
+         lists:duplicate(max(0, PadLen), $\x{2500}), [$\x{2510}]]),
+
+    %% Uptime line
+    UptimeLine = pad_line(io_lib:format(" Uptime: ~ts", [format_uptime(Uptime)]), Width),
+
+    BlankLine = pad_line("", Width),
+
+    %% HTTP section
+    HttpLines = case maps:size(HttpSnap) of
+        0 ->
+            [pad_line(" HTTP: no requests recorded", Width)];
+        _ ->
+            TotalReqs = lists:sum([maps:get(count, V) || {_, V} <- maps:to_list(HttpSnap)]),
+            TotalErrs = lists:sum([maps:get(errors, V) || {_, V} <- maps:to_list(HttpSnap)]),
+            SummaryLine = pad_line(
+                io_lib:format(" HTTP  Requests: ~B  Errors: ~B", [TotalReqs, TotalErrs]), Width),
+            Sorted = lists:reverse(lists:sort(
+                fun({_, A}, {_, B}) -> maps:get(count, A) < maps:get(count, B) end,
+                maps:to_list(HttpSnap))),
+            Top = lists:sublist(Sorted, 5),
+            EndpointLines = [begin
+                Count = maps:get(count, Stats),
+                AvgMs = maps:get(avg_ms, Stats),
+                Errs = maps:get(errors, Stats),
+                pad_line(io_lib:format("   ~ts  ~B req  ~Bms avg  ~B err",
+                    [pad_right(binary_to_list(Key), 25), Count, AvgMs, Errs]), Width)
+            end || {Key, Stats} <- Top],
+            [SummaryLine, BlankLine | EndpointLines]
+    end,
+
+    %% BEAM section
+    ProcCount = maps:get(process_count, Beam),
+    ProcLimit = maps:get(process_limit, Beam),
+    MemMB = maps:get(memory_total, Beam) div (1024 * 1024),
+    Schedulers = maps:get(scheduler_count, Beam),
+    BeamLines = [
+        pad_line(io_lib:format(" BEAM  Processes: ~B/~B  Memory: ~BMB  Schedulers: ~B",
+            [ProcCount, ProcLimit, MemMB, Schedulers]), Width)
+    ],
+
+    %% Custom counters/gauges
+    CustomLines = case {maps:size(Counters), maps:size(Gauges)} of
+        {0, 0} -> [];
+        _ ->
+            CounterEntries = [io_lib:format("~s: ~B", [K, V]) || {K, V} <- maps:to_list(Counters)],
+            GaugeEntries = [io_lib:format("~s: ~p", [K, V]) || {K, V} <- maps:to_list(Gauges)],
+            AllEntries = CounterEntries ++ GaugeEntries,
+            case AllEntries of
+                [] -> [];
+                _ ->
+                    [BlankLine,
+                     pad_line(" Custom Metrics", Width) |
+                     [pad_line(io_lib:format("   ~ts", [E]), Width) || E <- lists:sublist(AllEntries, 6)]]
+            end
+    end,
+
+    %% Bottom border
+    Bottom = io_lib:format("\e[1m~ts~ts~ts\e[0m~n",
+        [[$\x{2514}], lists:duplicate(Width - 2, $\x{2500}), [$\x{2518}]]),
+
+    lists:flatten([Header, UptimeLine, BlankLine] ++
+                  HttpLines ++ [BlankLine] ++
+                  BeamLines ++
+                  CustomLines ++
+                  [BlankLine, Bottom]).
+
+%% ── Helpers ──────────────────────────────────────────────────────────────────
+
+format_uptime(Secs) when Secs < 60 ->
+    io_lib:format("~Bs", [Secs]);
+format_uptime(Secs) when Secs < 3600 ->
+    io_lib:format("~Bm ~Bs", [Secs div 60, Secs rem 60]);
+format_uptime(Secs) ->
+    io_lib:format("~Bh ~Bm", [Secs div 3600, (Secs rem 3600) div 60]).
+
+pad_line(Text, Width) ->
+    Flat = lists:flatten(Text),
+    VisLen = visible_length(Flat),
+    Pad = max(0, Width - 2 - VisLen),
+    io_lib:format("\x{2502}~ts~ts\x{2502}~n", [Flat, lists:duplicate(Pad, $\s)]).
+
+visible_length(Str) ->
+    Re = "\e\\[[0-9;]*m",
+    Stripped = re:replace(Str, Re, "", [global, unicode, {return, list}]),
+    string:length(Stripped).
+
+pad_right(Str, Width) ->
+    Len = string:length(Str),
+    case Len >= Width of
+        true  -> string:slice(Str, 0, Width);
+        false -> Str ++ lists:duplicate(Width - Len, $\s)
+    end.

--- a/apps/winn/test/winn_metrics_dashboard_tests.erl
+++ b/apps/winn/test/winn_metrics_dashboard_tests.erl
@@ -1,0 +1,86 @@
+%% winn_metrics_dashboard_tests.erl
+%% Tests for the live metrics dashboard (#37).
+
+-module(winn_metrics_dashboard_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── CLI parse ───────────────────────────────────────────────────────────────
+
+parse_metrics_test() ->
+    ?assertEqual({metrics, []}, winn_cli:parse_args(["metrics"])).
+
+parse_metrics_snapshot_test() ->
+    ?assertEqual({metrics, ["--snapshot"]}, winn_cli:parse_args(["metrics", "--snapshot"])).
+
+%% ── Dashboard rendering ────────────────────────────────────────────────────
+
+dashboard_contains_title_test() ->
+    winn_metrics:enable(),
+    winn_metrics:reset_all(),
+    State = #{
+        snapshot => winn_metrics:snapshot(),
+        http => winn_metrics:http_snapshot(),
+        beam => winn_metrics:beam_stats(),
+        uptime => 120,
+        prev_snapshot => nil
+    },
+    Output = lists:flatten(winn_metrics_dashboard:format_dashboard(State)),
+    ?assert(string:find(Output, "Winn Metrics") =/= nomatch).
+
+dashboard_shows_beam_stats_test() ->
+    winn_metrics:enable(),
+    State = #{
+        snapshot => winn_metrics:snapshot(),
+        http => winn_metrics:http_snapshot(),
+        beam => winn_metrics:beam_stats(),
+        uptime => 60,
+        prev_snapshot => nil
+    },
+    Output = lists:flatten(winn_metrics_dashboard:format_dashboard(State)),
+    ?assert(string:find(Output, "BEAM") =/= nomatch),
+    ?assert(string:find(Output, "Processes") =/= nomatch),
+    ?assert(string:find(Output, "Memory") =/= nomatch).
+
+dashboard_shows_http_metrics_test() ->
+    winn_metrics:enable(),
+    winn_metrics:reset_all(),
+    winn_metrics:record_http(<<"GET">>, <<"/api/users">>, 200, 15),
+    winn_metrics:record_http(<<"GET">>, <<"/api/users">>, 200, 25),
+    State = #{
+        snapshot => winn_metrics:snapshot(),
+        http => winn_metrics:http_snapshot(),
+        beam => winn_metrics:beam_stats(),
+        uptime => 30,
+        prev_snapshot => nil
+    },
+    Output = lists:flatten(winn_metrics_dashboard:format_dashboard(State)),
+    ?assert(string:find(Output, "GET /api/users") =/= nomatch),
+    ?assert(string:find(Output, "2 req") =/= nomatch).
+
+dashboard_shows_custom_metrics_test() ->
+    winn_metrics:enable(),
+    winn_metrics:reset_all(),
+    winn_metrics:increment(orders_created, 47),
+    winn_metrics:set(queue_depth, 3),
+    State = #{
+        snapshot => winn_metrics:snapshot(),
+        http => winn_metrics:http_snapshot(),
+        beam => winn_metrics:beam_stats(),
+        uptime => 90,
+        prev_snapshot => nil
+    },
+    Output = lists:flatten(winn_metrics_dashboard:format_dashboard(State)),
+    ?assert(string:find(Output, "orders_created") =/= nomatch),
+    ?assert(string:find(Output, "queue_depth") =/= nomatch).
+
+dashboard_shows_uptime_test() ->
+    winn_metrics:enable(),
+    State = #{
+        snapshot => winn_metrics:snapshot(),
+        http => #{},
+        beam => winn_metrics:beam_stats(),
+        uptime => 3700,
+        prev_snapshot => nil
+    },
+    Output = lists:flatten(winn_metrics_dashboard:format_dashboard(State)),
+    ?assert(string:find(Output, "1h") =/= nomatch).


### PR DESCRIPTION
## Summary
- `winn metrics` — live terminal dashboard with ANSI rendering
- Shows HTTP per-endpoint stats, BEAM VM health, custom counters/gauges, uptime
- Auto-refreshes every 1 second
- 7 new tests (494 total, 0 failures)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)