### PR TITLE
Add built-in load testing (winn bench)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Winn language are documented here.
 - **BEAM VM stats** — `Metrics.beam_stats()` returns process count, memory, schedulers, uptime
 - **Snapshots** — `Metrics.snapshot()` and `Metrics.http_snapshot()` for reading all metrics
 - **`winn metrics`** — live terminal dashboard showing HTTP stats, BEAM health, custom metrics
+- **`winn bench`** — built-in load testing with concurrent workers, P50/P95/P99 latency stats
 
 ## [0.5.0] - 2026-04-01
 

--- a/apps/winn/src/winn_bench.erl
+++ b/apps/winn/src/winn_bench.erl
@@ -1,0 +1,120 @@
+%% winn_bench.erl
+%% Built-in load testing: spawn concurrent workers, collect latency stats.
+
+-module(winn_bench).
+-export([run/3, run_benchmarks/1, format_results/1, percentile/3]).
+
+%% ── Public API ───────────────────────────────────────────────────────────────
+
+%% Run a single benchmark.
+%% Fun/0 is called repeatedly by each worker for Duration seconds.
+%% Returns results map with count, avg, percentiles, errors.
+-spec run(atom(), map(), fun(() -> term())) -> map().
+run(Name, Opts, Fun) ->
+    Concurrency = maps:get(concurrent, Opts, 10),
+    Duration = maps:get(duration, Opts, 10),
+
+    io:format("~n  ~ts (~B concurrent, ~Bs)~n", [atom_to_list(Name), Concurrency, Duration]),
+    io:format("  ~ts~n", [lists:duplicate(40, $\x{2500})]),
+
+    Parent = self(),
+    Deadline = erlang:monotonic_time(millisecond) + (Duration * 1000),
+
+    %% Spawn workers
+    Workers = [spawn_link(fun() ->
+        worker_loop(Fun, Deadline, Parent, [])
+    end) || _ <- lists:seq(1, Concurrency)],
+
+    %% Collect results from all workers
+    AllResults = collect_results(length(Workers), []),
+
+    %% Aggregate
+    Results = aggregate(Name, AllResults, Duration),
+    print_results(Results),
+    Results.
+
+%% Run benchmarks from a compiled module that exports __bench__/0.
+run_benchmarks(Module) ->
+    Benchmarks = Module:'__bench__'(),
+    io:format("  Winn Bench — ~B benchmark(s)~n", [length(Benchmarks)]),
+    lists:map(fun({Name, Opts, Fun}) ->
+        run(Name, Opts, Fun)
+    end, Benchmarks).
+
+%% ── Worker ──────────────────────────────────────────────────────────────────
+
+worker_loop(Fun, Deadline, Parent, Acc) ->
+    Now = erlang:monotonic_time(millisecond),
+    case Now >= Deadline of
+        true ->
+            Parent ! {bench_result, self(), Acc};
+        false ->
+            Start = erlang:monotonic_time(microsecond),
+            Status = try
+                Fun(),
+                ok
+            catch
+                _:_ -> error
+            end,
+            Elapsed = erlang:monotonic_time(microsecond) - Start,
+            LatencyMs = Elapsed / 1000,
+            worker_loop(Fun, Deadline, Parent, [{LatencyMs, Status} | Acc])
+    end.
+
+collect_results(0, Acc) -> lists:flatten(Acc);
+collect_results(N, Acc) ->
+    receive
+        {bench_result, _Pid, Results} ->
+            collect_results(N - 1, [Results | Acc])
+    after 30000 ->
+        lists:flatten(Acc)
+    end.
+
+%% ── Aggregation ─────────────────────────────────────────────────────────────
+
+aggregate(Name, Results, Duration) ->
+    Latencies = [L || {L, _} <- Results],
+    Errors = length([S || {_, S} <- Results, S =:= error]),
+    Total = length(Results),
+    Sorted = lists:sort(Latencies),
+    Len = length(Sorted),
+
+    #{name => Name,
+      total => Total,
+      rps => case Duration of 0 -> 0; _ -> Total div Duration end,
+      errors => Errors,
+      error_rate => case Total of 0 -> 0.0; _ -> Errors / Total * 100 end,
+      avg => case Len of 0 -> 0; _ -> round(lists:sum(Sorted) / Len) end,
+      min => case Sorted of [] -> 0; _ -> round(hd(Sorted)) end,
+      max => case Sorted of [] -> 0; _ -> round(lists:last(Sorted)) end,
+      p50 => percentile(Sorted, Len, 50),
+      p95 => percentile(Sorted, Len, 95),
+      p99 => percentile(Sorted, Len, 99)}.
+
+%% ── Display ─────────────────────────────────────────────────────────────────
+
+print_results(R) ->
+    #{name := _Name, total := Total, rps := Rps,
+      avg := Avg, p50 := P50, p95 := P95, p99 := P99,
+      min := Min, max := Max, errors := Errors, error_rate := ErrRate} = R,
+    io:format("  Requests:     ~B     (~B/s)~n", [Total, Rps]),
+    io:format("  Avg latency:  ~Bms~n", [Avg]),
+    io:format("  P50:          ~Bms~n", [P50]),
+    io:format("  P95:          ~Bms~n", [P95]),
+    io:format("  P99:          ~Bms~n", [P99]),
+    io:format("  Min/Max:      ~Bms / ~Bms~n", [Min, Max]),
+    io:format("  Errors:       ~B         (~.1f%)~n", [Errors, ErrRate]).
+
+format_results(R) ->
+    #{name := Name, total := Total, rps := Rps,
+      avg := Avg, p50 := P50, p95 := P95, p99 := P99,
+      errors := Errors} = R,
+    io_lib:format("~s: ~B reqs (~B/s) avg=~Bms p50=~Bms p95=~Bms p99=~Bms errs=~B",
+        [Name, Total, Rps, Avg, P50, P95, P99, Errors]).
+
+%% ── Helpers ─────────────────────────────────────────────────────────────────
+
+percentile(_, 0, _) -> 0;
+percentile(Sorted, Len, P) ->
+    Index = max(1, min(Len, round(P / 100 * Len))),
+    round(lists:nth(Index, Sorted)).

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -55,6 +55,9 @@ main(Args) ->
         {task, TaskArgs} ->
             run_task(TaskArgs);
 
+        {bench, BenchArgs} ->
+            run_bench(BenchArgs);
+
         {metrics, MetricsArgs} ->
             winn_metrics_dashboard:start(#{args => MetricsArgs});
 
@@ -103,6 +106,7 @@ parse_args(["watch" | Args])       -> {watch, Args};
 parse_args(["task" | Args])        -> {task, Args};
 parse_args(["create" | Args])      -> {create, Args};
 parse_args(["c" | Args])           -> {create, Args};
+parse_args(["bench" | Args])       -> {bench, Args};
 parse_args(["metrics" | Args])     -> {metrics, Args};
 parse_args(["release" | Args])     -> {release, Args};
 parse_args(["migrate" | Args])     -> {migrate, Args};
@@ -421,6 +425,43 @@ load_test_beams(Dir, _Compiled) ->
         end
     end, Beams).
 
+%% ── Benchmarking ────────────────────────────────────────────────────────
+
+run_bench([File | _]) ->
+    OutDir = "_build/bench",
+    ok = filelib:ensure_path(OutDir),
+    %% Compile src/ first (for project modules)
+    SrcFiles = filelib:wildcard("src/*.winn"),
+    lists:foreach(fun(F) ->
+        case winn:compile_file(F, OutDir) of
+            {ok, _} -> ok;
+            _ -> ok
+        end
+    end, SrcFiles),
+    %% Compile the bench file
+    case winn:compile_file(File, OutDir) of
+        {ok, _} ->
+            code:add_patha(OutDir),
+            ModAtom = detect_module_name(File),
+            code:purge(ModAtom),
+            code:load_file(ModAtom),
+            case erlang:function_exported(ModAtom, '__bench__', 0) of
+                true ->
+                    winn_bench:run_benchmarks(ModAtom),
+                    halt(0);
+                false ->
+                    io:format("Error: ~s does not export __bench__/0~n"
+                              "Use `use Winn.Bench` and define bench blocks.~n", [ModAtom]),
+                    halt(1)
+            end;
+        {error, Reason} ->
+            io:format("Error compiling ~s: ~p~n", [File, Reason]),
+            halt(1)
+    end;
+run_bench([]) ->
+    io:format("Usage: winn bench <file>~n"),
+    halt(0).
+
 %% ── Release / deployment ────────────────────────────────────────────────
 
 run_release(["--docker"]) ->
@@ -714,6 +755,7 @@ print_usage() ->
         "  winn watch              Watch files and hot-reload with live dashboard~n"
         "  winn watch --start      Watch + start the app~n"
         "  winn task <name>        Run a project task (e.g., winn task db:seed)~n"
+        "  winn bench <file>       Run load tests~n"
         "  winn metrics            Live metrics dashboard~n"
         "  winn release            Build a production release~n"
         "  winn release --docker   Generate a Dockerfile~n"

--- a/apps/winn/test/winn_bench_tests.erl
+++ b/apps/winn/test/winn_bench_tests.erl
@@ -1,0 +1,65 @@
+%% winn_bench_tests.erl
+%% Tests for built-in load testing (#35).
+
+-module(winn_bench_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── CLI parse ───────────────────────────────────────────────────────────────
+
+parse_bench_test() ->
+    ?assertEqual({bench, ["bench/api.winn"]},
+                 winn_cli:parse_args(["bench", "bench/api.winn"])).
+
+%% ── Percentile calculation ──────────────────────────────────────────────────
+
+percentile_empty_test() ->
+    ?assertEqual(0, winn_bench:percentile([], 0, 50)).
+
+percentile_single_test() ->
+    ?assertEqual(42, winn_bench:percentile([42], 1, 50)).
+
+percentile_p50_test() ->
+    Sorted = lists:seq(1, 100),
+    ?assertEqual(50, winn_bench:percentile(Sorted, 100, 50)).
+
+percentile_p99_test() ->
+    Sorted = lists:seq(1, 100),
+    ?assertEqual(99, winn_bench:percentile(Sorted, 100, 99)).
+
+%% ── Run a simple benchmark ──────────────────────────────────────────────────
+
+run_simple_bench_test() ->
+    Counter = counters:new(1, []),
+    Results = winn_bench:run(test_bench, #{concurrent => 2, duration => 1}, fun() ->
+        counters:add(Counter, 1, 1),
+        ok
+    end),
+    ?assert(maps:get(total, Results) > 0),
+    ?assert(maps:get(avg, Results) >= 0),
+    ?assertEqual(0, maps:get(errors, Results)),
+    ?assert(maps:get(p50, Results) >= 0),
+    ?assert(maps:get(p99, Results) >= 0).
+
+%% ── Bench with errors ───────────────────────────────────────────────────────
+
+run_bench_with_errors_test() ->
+    Counter = counters:new(1, []),
+    Results = winn_bench:run(error_bench, #{concurrent => 1, duration => 1}, fun() ->
+        counters:add(Counter, 1, 1),
+        case counters:get(Counter, 1) rem 3 of
+            0 -> error(intentional);
+            _ -> ok
+        end
+    end),
+    ?assert(maps:get(errors, Results) > 0),
+    ?assert(maps:get(error_rate, Results) > 0).
+
+%% ── Format results ──────────────────────────────────────────────────────────
+
+format_results_test() ->
+    R = #{name => test, total => 100, rps => 50,
+          avg => 10, p50 => 8, p95 => 20, p99 => 30,
+          min => 2, max => 45, errors => 1, error_rate => 1.0},
+    Formatted = lists:flatten(winn_bench:format_results(R)),
+    ?assert(string:find(Formatted, "100 reqs") =/= nomatch),
+    ?assert(string:find(Formatted, "50/s") =/= nomatch).


### PR DESCRIPTION
## Summary
- `winn bench <file>` — load testing with concurrent BEAM workers
- P50/P95/P99 latency stats, error rates, requests/second
- Configurable concurrency and duration per benchmark
- 8 new tests (502 total, 0 failures)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)