### PR TITLE
Add static file serving

### DIFF
--- a/apps/winn/src/winn_server.erl
+++ b/apps/winn/src/winn_server.erl
@@ -20,7 +20,7 @@
 %%   Server.path(conn)              -> binary
 
 -module(winn_server).
--export([start/2, stop/0]).
+-export([start/2, start/3, stop/0, build_static_routes/1]).
 -export([json/2, json/3, text/2, text/3, send/4]).
 -export([body_params/1, path_param/2, query_param/2, header/2]).
 -export([method/1, path/1]).
@@ -32,8 +32,37 @@
 
 start(RouterModule, Port) when is_atom(RouterModule), is_integer(Port) ->
     application:ensure_all_started(cowboy),
+    %% Extract static routes from the router's routes/0
+    Routes = case erlang:function_exported(RouterModule, routes, 0) of
+        true  -> RouterModule:routes();
+        false -> []
+    end,
+    StaticRoutes = build_static_routes(Routes),
+    %% Catch-all route for the Winn router handler
+    CatchAll = {'_', winn_router, #{router => RouterModule}},
     Dispatch = cowboy_router:compile([
-        {'_', [{'_', winn_router, #{router => RouterModule}}]}
+        {'_', StaticRoutes ++ [CatchAll]}
+    ]),
+    cowboy:start_clear(?LISTENER, [{port, Port}], #{
+        env => #{dispatch => Dispatch}
+    }).
+
+%% Server.start(RouterModule, Port, Opts) — with static directory option
+start(RouterModule, Port, Opts) when is_atom(RouterModule), is_integer(Port), is_map(Opts) ->
+    application:ensure_all_started(cowboy),
+    Routes = case erlang:function_exported(RouterModule, routes, 0) of
+        true  -> RouterModule:routes();
+        false -> []
+    end,
+    %% Add explicit static dir from opts
+    ExtraStatic = case maps:get(static, Opts, undefined) of
+        undefined -> [];
+        {UrlPath, Dir} -> [{UrlPath, Dir}]
+    end,
+    StaticRoutes = build_static_routes(Routes ++ [{static, P, D} || {P, D} <- ExtraStatic]),
+    CatchAll = {'_', winn_router, #{router => RouterModule}},
+    Dispatch = cowboy_router:compile([
+        {'_', StaticRoutes ++ [CatchAll]}
     ]),
     cowboy:start_clear(?LISTENER, [{port, Port}], #{
         env => #{dispatch => Dispatch}
@@ -128,3 +157,37 @@ prepare_json(nil) ->
     null;
 prepare_json(Other) ->
     Other.
+
+%% ── Static file routing ────────────────────────────────────────────────
+%% Converts {:static, "/public", "static/"} route tuples into
+%% Cowboy-compatible static file dispatch rules.
+
+build_static_routes(Routes) ->
+    lists:filtermap(fun
+        ({static, UrlPrefix, Dir}) ->
+            build_one_static(UrlPrefix, Dir);
+        (_) ->
+            false
+    end, Routes).
+
+build_one_static(UrlPrefix, Dir) ->
+    %% Convert Winn path prefix to Cowboy match pattern
+    %% "/public" -> "/public/[...]"
+    Prefix = case is_binary(UrlPrefix) of
+        true  -> binary_to_list(UrlPrefix);
+        false -> UrlPrefix
+    end,
+    DirStr = case is_binary(Dir) of
+        true  -> binary_to_list(Dir);
+        false -> Dir
+    end,
+    %% Ensure directory exists
+    AbsDir = filename:absname(DirStr),
+    case filelib:is_dir(AbsDir) of
+        true ->
+            Pattern = Prefix ++ "/[...]",
+            {true, {Pattern, cowboy_static, {dir, AbsDir,
+                [{mimetypes, cow_mimetypes, all}]}}};
+        false ->
+            false
+    end.

--- a/apps/winn/test/winn_static_tests.erl
+++ b/apps/winn/test/winn_static_tests.erl
@@ -1,0 +1,86 @@
+%% winn_static_tests.erl
+%% Tests for static file serving (#47).
+
+-module(winn_static_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Static route extraction ─────────────────────────────────────────────────
+
+build_static_routes_test() ->
+    %% Create a temp directory with a file
+    Dir = "/tmp/winn_static_test_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_path(Dir),
+    file:write_file(Dir ++ "/index.html", <<"<h1>Hello</h1>">>),
+
+    Routes = [{static, "/public", Dir}],
+    Result = winn_server:build_static_routes(Routes),
+    ?assertEqual(1, length(Result)),
+
+    %% Verify the Cowboy route pattern
+    {Pattern, cowboy_static, {dir, _, _}} = hd(Result),
+    ?assertEqual("/public/[...]", Pattern),
+
+    os:cmd("rm -rf " ++ Dir).
+
+build_static_routes_nonexistent_dir_test() ->
+    Routes = [{static, "/assets", "/nonexistent/path/xyz"}],
+    Result = winn_server:build_static_routes(Routes),
+    ?assertEqual([], Result).
+
+build_static_routes_mixed_test() ->
+    Dir = "/tmp/winn_static_mix_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_path(Dir),
+
+    Routes = [
+        {get, "/api/users", list_users},
+        {static, "/public", Dir},
+        {post, "/api/users", create_user}
+    ],
+    Result = winn_server:build_static_routes(Routes),
+    %% Only the static route should be extracted
+    ?assertEqual(1, length(Result)),
+
+    os:cmd("rm -rf " ++ Dir).
+
+build_static_routes_empty_test() ->
+    Result = winn_server:build_static_routes([]),
+    ?assertEqual([], Result).
+
+%% ── Router skips static routes ──────────────────────────────────────────────
+
+router_skips_static_test() ->
+    %% Static routes should not match in the Winn router
+    Routes = [
+        {static, "/public", "static/"},
+        {get, <<"/api">>, handler}
+    ],
+    ?assertEqual(nomatch, winn_router:match_route(get, <<"/public/style.css">>, Routes)),
+    ?assertMatch({ok, handler, _}, winn_router:match_route(get, <<"/api">>, Routes)).
+
+%% ── Compiles from Winn source ───────────────────────────────────────────────
+
+static_in_routes_compiles_test() ->
+    Source = "module StaticRouter\n"
+             "  use Winn.Router\n"
+             "\n"
+             "  def routes()\n"
+             "    [\n"
+             "      {:static, \"/public\", \"static/\"},\n"
+             "      {:get, \"/\", :index}\n"
+             "    ]\n"
+             "  end\n"
+             "\n"
+             "  def index(conn)\n"
+             "    Server.json(conn, %{status: \"ok\"})\n"
+             "  end\n"
+             "end\n",
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST} = winn_parser:parse(Tokens),
+    Transformed = winn_transform:transform(AST),
+    [CoreMod] = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    Routes = ModName:routes(),
+    ?assertMatch([{static, _, _}, {get, _, _}], Routes).


### PR DESCRIPTION
## Summary
- `{:static, "/public", "static/"}` route type serves files from a directory
- Uses Cowboy's built-in `cowboy_static` with MIME type detection
- Static routes added to Cowboy dispatch at startup, bypassing Winn router
- `Server.start/3` with opts map for explicit static dir config
- 6 new tests (543 total, 0 failures)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)