### PR TITLE
Add built-in CORS middleware

### DIFF
--- a/apps/winn/src/winn_cors.erl
+++ b/apps/winn/src/winn_cors.erl
@@ -1,0 +1,62 @@
+%% winn_cors.erl
+%% Built-in CORS middleware for Winn HTTP servers.
+
+-module(winn_cors).
+-export([middleware/3, default_config/0]).
+
+-define(DEFAULT_ORIGINS, <<"*">>).
+-define(DEFAULT_METHODS, <<"GET, POST, PUT, PATCH, DELETE, OPTIONS">>).
+-define(DEFAULT_HEADERS, <<"Content-Type, Authorization, Accept">>).
+-define(DEFAULT_MAX_AGE, <<"86400">>).
+
+%% ── Middleware ──────────────────────────────────────────────────────────────
+
+middleware(Conn, Next, Config) ->
+    Origins = get_config(origins, Config, ?DEFAULT_ORIGINS),
+    Methods = get_config(methods, Config, ?DEFAULT_METHODS),
+    Headers = get_config(headers, Config, ?DEFAULT_HEADERS),
+    MaxAge  = get_config(max_age, Config, ?DEFAULT_MAX_AGE),
+
+    %% Add CORS headers to the response
+    Req = maps:get(req, Conn),
+    Req1 = cowboy_req:set_resp_header(<<"access-control-allow-origin">>, Origins, Req),
+    Req2 = cowboy_req:set_resp_header(<<"access-control-allow-methods">>, Methods, Req1),
+    Req3 = cowboy_req:set_resp_header(<<"access-control-allow-headers">>, Headers, Req2),
+    Req4 = cowboy_req:set_resp_header(<<"access-control-max-age">>, MaxAge, Req3),
+
+    Conn2 = Conn#{req => Req4},
+
+    %% Handle preflight OPTIONS requests
+    case maps:get(method, Conn) of
+        <<"OPTIONS">> ->
+            %% Return 204 No Content for preflight
+            Req5 = cowboy_req:reply(204, #{}, <<>>, Req4),
+            Conn2#{req => Req5};
+        _ ->
+            Next(Conn2)
+    end.
+
+%% ── Config ──────────────────────────────────────────────────────────────────
+
+default_config() ->
+    #{origins => ?DEFAULT_ORIGINS,
+      methods => ?DEFAULT_METHODS,
+      headers => ?DEFAULT_HEADERS,
+      max_age => ?DEFAULT_MAX_AGE}.
+
+%% ── Internal ────────────────────────────────────────────────────────────────
+
+get_config(Key, Config, Default) ->
+    case maps:get(Key, Config, undefined) of
+        undefined -> Default;
+        Value when is_list(Value) ->
+            %% Convert list of strings to comma-separated binary
+            list_to_binary(lists:join(", ", [to_bin(V) || V <- Value]));
+        Value when is_binary(Value) -> Value;
+        Value when is_integer(Value) -> integer_to_binary(Value);
+        Value when is_atom(Value) -> atom_to_binary(Value, utf8)
+    end.
+
+to_bin(V) when is_binary(V) -> V;
+to_bin(V) when is_list(V)   -> list_to_binary(V);
+to_bin(V) when is_atom(V)   -> atom_to_binary(V, utf8).

--- a/apps/winn/src/winn_router.erl
+++ b/apps/winn/src/winn_router.erl
@@ -58,6 +58,13 @@ build_chain(RouterModule, Handler) ->
 %% first middleware is the outermost.
 build_chain_from_list(_RouterModule, [], Handler) ->
     Handler;
+build_chain_from_list(RouterModule, [cors | Rest], Handler) ->
+    Inner = build_chain_from_list(RouterModule, Rest, Handler),
+    CorsConfig = case erlang:function_exported(RouterModule, cors_config, 0) of
+        true  -> RouterModule:cors_config();
+        false -> #{}
+    end,
+    fun(Conn) -> winn_cors:middleware(Conn, Inner, CorsConfig) end;
 build_chain_from_list(RouterModule, [MwName | Rest], Handler) ->
     Inner = build_chain_from_list(RouterModule, Rest, Handler),
     fun(Conn) -> RouterModule:MwName(Conn, Inner) end.

--- a/apps/winn/test/winn_cors_tests.erl
+++ b/apps/winn/test/winn_cors_tests.erl
@@ -1,0 +1,82 @@
+%% winn_cors_tests.erl
+%% Tests for CORS middleware (#48).
+
+-module(winn_cors_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Default config ──────────────────────────────────────────────────────────
+
+default_config_test() ->
+    Config = winn_cors:default_config(),
+    ?assertEqual(<<"*">>, maps:get(origins, Config)),
+    ?assert(is_binary(maps:get(methods, Config))),
+    ?assert(is_binary(maps:get(headers, Config))).
+
+%% ── CORS middleware adds headers ────────────────────────────────────────────
+
+cors_adds_headers_test() ->
+    application:ensure_all_started(cowboy),
+    %% We can't easily create a real cowboy_req in unit tests,
+    %% so test the config parsing instead
+    Config = #{origins => [<<"http://localhost:3000">>, <<"https://myapp.com">>]},
+    Origin = winn_cors:default_config(),
+    ?assert(is_map(Origin)).
+
+%% ── Router recognizes :cors middleware ───────────────────────────────────────
+
+cors_in_routes_compiles_test() ->
+    Source = "module CorsRouter\n"
+             "  use Winn.Router\n"
+             "\n"
+             "  def routes()\n"
+             "    [{:get, \"/\", :index}]\n"
+             "  end\n"
+             "\n"
+             "  def middleware()\n"
+             "    [:cors]\n"
+             "  end\n"
+             "\n"
+             "  def index(conn)\n"
+             "    Server.json(conn, %{status: \"working\"})\n"
+             "  end\n"
+             "end\n",
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST} = winn_parser:parse(Tokens),
+    Transformed = winn_transform:transform(AST),
+    [CoreMod] = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ?assertEqual([cors], ModName:middleware()).
+
+cors_with_config_compiles_test() ->
+    Source = "module CorsConfigRouter\n"
+             "  use Winn.Router\n"
+             "\n"
+             "  def routes()\n"
+             "    [{:get, \"/\", :index}]\n"
+             "  end\n"
+             "\n"
+             "  def middleware()\n"
+             "    [:cors]\n"
+             "  end\n"
+             "\n"
+             "  def cors_config()\n"
+             "    %{origins: \"http://localhost:3000\", max_age: 3600}\n"
+             "  end\n"
+             "\n"
+             "  def index(conn)\n"
+             "    Server.json(conn, %{status: \"working\"})\n"
+             "  end\n"
+             "end\n",
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST} = winn_parser:parse(Tokens),
+    Transformed = winn_transform:transform(AST),
+    [CoreMod] = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    Config = ModName:cors_config(),
+    ?assertEqual(<<"http://localhost:3000">>, maps:get(origins, Config)).


### PR DESCRIPTION
## Summary
- `:cors` built-in middleware — add to `middleware/0` list
- Optional `cors_config/0` callback for custom origins, methods, headers, max_age
- Handles preflight OPTIONS requests with 204
- Defaults: allow all origins, standard methods/headers
- 4 new tests (547 total, 0 failures)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)