### PR TITLE
Add `agent` keyword — stateful actors as a language primitive

### DIFF
--- a/apps/winn/src/winn_agent.erl
+++ b/apps/winn/src/winn_agent.erl
@@ -1,0 +1,15 @@
+%% winn_agent.erl
+%% Runtime helpers for Winn agents (stateful actors).
+%% Agents are GenServers under the hood; this module provides
+%% convenience functions for managing agent lifecycle.
+
+-module(winn_agent).
+-export([stop/1, stop/2]).
+
+%% Stop an agent gracefully.
+stop(Pid) ->
+    gen_server:stop(Pid).
+
+%% Stop an agent with a reason and timeout.
+stop(Pid, Reason) ->
+    gen_server:stop(Pid, Reason, 5000).

--- a/apps/winn/src/winn_codegen.erl
+++ b/apps/winn/src/winn_codegen.erl
@@ -327,6 +327,7 @@ resolve_dot_call('Regex', Fun) -> {winn_regex, Fun};
 resolve_dot_call('Protocol', Fun) -> {winn_protocol, Fun};
 resolve_dot_call('Health', Fun)   -> {winn_health, Fun};
 resolve_dot_call('Metrics', Fun)  -> {winn_metrics, Fun};
+resolve_dot_call('Agent', Fun)    -> {winn_agent, Fun};
 resolve_dot_call('ReplBindings', get) -> {winn_repl, get_binding};
 resolve_dot_call(Mod, Fun) ->
     ErlMod = list_to_atom(string:lowercase(atom_to_list(Mod))),

--- a/apps/winn/src/winn_lexer.xrl
+++ b/apps/winn/src/winn_lexer.xrl
@@ -37,6 +37,8 @@ Rules.
 
 %% Keywords — must appear before the identifier catch-all
 module                      : {token, {'module', TokenLine}}.
+agent                       : {token, {'agent', TokenLine}}.
+async                       : {token, {'async', TokenLine}}.
 def                         : {token, {'def', TokenLine}}.
 struct                      : {token, {'struct', TokenLine}}.
 protocol                    : {token, {'protocol', TokenLine}}.
@@ -79,6 +81,9 @@ order_by                    : {token, {'order_by', TokenLine}}.
 limit                       : {token, {'limit_kw', TokenLine}}.
 offset                      : {token, {'offset_kw', TokenLine}}.
 preload                     : {token, {'preload', TokenLine}}.
+
+%% State reference (@var) for agent state access
+@{A}{AN}*                   : {token, {state_ref, TokenLine, list_to_atom(tl(TokenChars))}}.
 
 %% Atom literals (:foo)
 :{A}{AN}*                   : {token, {atom_lit, TokenLine, list_to_atom(tl(TokenChars))}}.

--- a/apps/winn/src/winn_newline_filter.erl
+++ b/apps/winn/src/winn_newline_filter.erl
@@ -54,7 +54,7 @@ pass2([{rescue, _} = Tok | Rest], Ctx, Acc) ->
 %% Enter other keyword contexts (if, try, match, fn, for, def) that have 'end'
 pass2([{T, _} = Tok | Rest], Ctx, Acc)
   when T =:= 'if'; T =:= 'try'; T =:= 'match'; T =:= 'fn';
-       T =:= 'for'; T =:= 'def'; T =:= 'do' ->
+       T =:= 'for'; T =:= 'def'; T =:= 'do'; T =:= 'agent' ->
     pass2(Rest, [other | Ctx], [Tok | Acc]);
 
 %% Pop context on 'end'

--- a/apps/winn/src/winn_parser.yrl
+++ b/apps/winn/src/winn_parser.yrl
@@ -16,6 +16,7 @@ Nonterminals
     program
     top_forms top_form
     module_def module_body dotted_name
+    agent_def agent_body agent_item agent_state_decl agent_function_def
     use_directive import_directive alias_directive
     function_def struct_def struct_fields protocol_def impl_def protocol_fns param_list pattern_list
     expr_seq
@@ -37,12 +38,12 @@ Nonterminals
 
 %% Phase 1 terminals + Phase 2 additions.
 Terminals
-    'module' 'def' 'struct' 'protocol' 'impl' 'do' 'end' 'use' 'import' 'alias' 'schema' 'field'
+    'module' 'agent' 'async' 'def' 'struct' 'protocol' 'impl' 'do' 'end' 'use' 'import' 'alias' 'schema' 'field'
     'match' 'ok_kw' 'err_kw' 'nil_kw'
     'if' 'else' 'switch' 'when' 'try' 'rescue'
     'fn' 'for' 'in'
     'and' 'or' 'not'
-    ident module_name
+    ident module_name state_ref
     atom_lit integer_lit float_lit string_lit interp_string boolean_lit
     '|>' '|>=' '=>' '..'
     '<>'
@@ -64,6 +65,34 @@ top_forms -> '$empty' : [].
 top_forms -> top_form top_forms : ['$1' | '$2'].
 
 top_form -> module_def : '$1'.
+top_form -> agent_def  : '$1'.
+
+%% ── Agent ────────────────────────────────────────────────────────────────────
+
+agent_def -> 'agent' dotted_name agent_body 'end'
+    : {agent, line('$1'), '$2', '$3'}.
+
+agent_body -> '$empty' : [].
+agent_body -> agent_item agent_body : ['$1' | '$2'].
+
+agent_item -> agent_state_decl : '$1'.
+agent_item -> agent_function_def : '$1'.
+
+%% state count = 0
+agent_state_decl -> ident ident '=' expr
+    : {state_decl, line('$1'), val('$2'), '$4'}.
+
+%% Sync function: def value() ... end
+agent_function_def -> 'def' ident '(' param_list ')' expr_seq 'end'
+    : {agent_fn, line('$1'), val('$2'), '$4', '$6'}.
+
+%% Sync function with guard: def withdraw(amount) when amount > 0 ... end
+agent_function_def -> 'def' ident '(' param_list ')' 'when' expr expr_seq 'end'
+    : {agent_fn_g, line('$1'), val('$2'), '$4', '$7', '$8'}.
+
+%% Async (cast) function: async def log(msg) ... end
+agent_function_def -> 'async' 'def' ident '(' param_list ')' expr_seq 'end'
+    : {agent_cast_fn, line('$1'), val('$3'), '$5', '$7'}.
 
 %% ── Module ─────────────────────────────────────────────────────────────────
 
@@ -204,6 +233,12 @@ primary_expr -> switch_expr                : '$1'.
 primary_expr -> try_expr                   : '$1'.
 primary_expr -> fn_expr                    : '$1'.
 primary_expr -> for_expr                   : '$1'.
+
+%% State access: @count (read), @count = expr (write)
+primary_expr -> state_ref
+    : {state_read, line('$1'), val('$1')}.
+primary_expr -> state_ref '=' expr
+    : {state_write, line('$1'), val('$1'), '$3'}.
 
 %% Assignment: x = expr (parsed at statement level via primary_expr)
 primary_expr -> ident '=' expr

--- a/apps/winn/src/winn_transform.erl
+++ b/apps/winn/src/winn_transform.erl
@@ -69,6 +69,57 @@ transform_form({module, Line, Name, Body}) ->
     end,
 
     {module, Line, Name, BehaviourAttrs ++ SyntheticFns ++ Final};
+%% ── Agent desugaring ─────────────────────────────────────────────────────
+%% An `agent` block is desugared into a module with GenServer infrastructure.
+%% The result is fed back into transform_form({module,...}) for normal processing.
+
+transform_form({agent, Line, Name, Items}) ->
+    %% 1. Partition items into state declarations and functions
+    {StateDefs, AgentFns} = lists:partition(
+        fun({state_decl,_,_,_}) -> true; (_) -> false end, Items),
+
+    %% 2. Build default state map
+    DefaultState = {map, Line, [{VName, Expr} || {state_decl, _, VName, Expr} <- StateDefs]},
+
+    ModAtom = lower_module_atom(Name),
+
+    %% 3. Generate behaviour attribute
+    BehavAttr = {behaviour_attr, Line, gen_server},
+
+    %% 4. Generate start/0 and start/1
+    StartFn0 = gen_agent_start(Line, ModAtom, DefaultState),
+    StartFn1 = gen_agent_start_with_overrides(Line, ModAtom, DefaultState),
+
+    %% 5. Generate init/1
+    InitFn = {function, Line, init, [{var, Line, '__init_state__'}],
+              [{tuple, Line, [{atom, Line, ok}, {var, Line, '__init_state__'}]}]},
+
+    %% 6. For each agent function, generate client fn + handle clause
+    FnPairs = [gen_agent_fn_pair(F, ModAtom) || F <- AgentFns],
+    ClientFns = [C || {C, _} <- FnPairs],
+    HandleFns = [H || {_, H} <- FnPairs],
+
+    %% Group handle_call and handle_cast separately so merge_fn_clauses works
+    HandleCalls = [H || {function, _, handle_call, _, _} = H <- HandleFns]
+              ++ [H || {function_g, _, handle_call, _, _, _} = H <- HandleFns],
+    HandleCasts = [H || {function, _, handle_cast, _, _} = H <- HandleFns],
+
+    %% 7. Generate default handle_cast, handle_info, terminate
+    DefaultCast = {function, Line, handle_cast, [{var, Line, '__msg__'}, {var, Line, '__agent_state__'}],
+                   [{tuple, Line, [{atom, Line, noreply}, {var, Line, '__agent_state__'}]}]},
+    DefaultInfo = {function, Line, handle_info, [{var, Line, '__msg__'}, {var, Line, '__agent_state__'}],
+                   [{tuple, Line, [{atom, Line, noreply}, {var, Line, '__agent_state__'}]}]},
+    DefaultTerm = {function, Line, terminate, [{var, Line, '__reason__'}, {var, Line, '__agent_state__'}],
+                   [{atom, Line, ok}]},
+
+    %% 8. Assemble as a module — group same-name functions adjacently for merge
+    ModuleBody = [BehavAttr, StartFn0, StartFn1 | ClientFns]
+              ++ [InitFn]
+              ++ HandleCalls
+              ++ HandleCasts ++ [DefaultCast]
+              ++ [DefaultInfo, DefaultTerm],
+    transform_form({module, Line, Name, ModuleBody});
+
 transform_form(Other) ->
     Other.
 
@@ -115,6 +166,210 @@ expand_use(Line, 'Winn', 'Test', _ModName) ->
     {behaviour_only, Attr};
 expand_use(_Line, 'Winn', 'Schema', _ModName) ->
     {schema_use, none}.
+
+%% ── Agent helper functions ──────────────────────────────────────────────
+
+%% start/0: start with default state, unwrap {:ok, pid} to just pid
+gen_agent_start(L, ModAtom, DefaultState) ->
+    {function, L, start, [],
+     [{pat_assign, L,
+         {tuple, L, [{atom, L, ok}, {var, L, '__agent_pid__'}]},
+         {dot_call, L, 'GenServer', start, [
+             {atom, L, ModAtom},
+             DefaultState,
+             {list, L, []}
+         ]}},
+      {var, L, '__agent_pid__'}]}.
+
+%% start/1: merge overrides into defaults, then start
+gen_agent_start_with_overrides(L, ModAtom, DefaultState) ->
+    {function, L, start, [{var, L, '__overrides__'}],
+     [{assign, L, {var, L, '__merged__'},
+         {dot_call, L, 'Map', merge, [DefaultState, {var, L, '__overrides__'}]}},
+      {pat_assign, L,
+         {tuple, L, [{atom, L, ok}, {var, L, '__agent_pid__'}]},
+         {dot_call, L, 'GenServer', start, [
+             {atom, L, ModAtom},
+             {var, L, '__merged__'},
+             {list, L, []}
+         ]}},
+      {var, L, '__agent_pid__'}]}.
+
+%% Generate client function + handle clause for an agent function
+gen_agent_fn_pair({agent_fn, L, FnName, Params, Body}, _ModAtom) ->
+    gen_sync_pair(L, FnName, Params, Body);
+gen_agent_fn_pair({agent_fn_g, L, FnName, Params, Guard, Body}, _ModAtom) ->
+    gen_sync_pair_guarded(L, FnName, Params, Guard, Body);
+gen_agent_fn_pair({agent_cast_fn, L, FnName, Params, Body}, _ModAtom) ->
+    gen_cast_pair(L, FnName, Params, Body).
+
+%% Sync (gen_server:call) — client + handle_call
+gen_sync_pair(L, FnName, Params, Body) ->
+    ClientFn = gen_client_fn(L, FnName, Params, call),
+    HandleFn = gen_handle_call(L, FnName, Params, none, Body),
+    {ClientFn, HandleFn}.
+
+gen_sync_pair_guarded(L, FnName, Params, Guard, Body) ->
+    ClientFn = gen_client_fn(L, FnName, Params, call),
+    HandleFn = gen_handle_call(L, FnName, Params, Guard, Body),
+    {ClientFn, HandleFn}.
+
+%% Async (gen_server:cast) — client + handle_cast
+gen_cast_pair(L, FnName, Params, Body) ->
+    ClientFn = gen_client_fn(L, FnName, Params, cast),
+    HandleFn = gen_handle_cast(L, FnName, Params, Body),
+    {ClientFn, HandleFn}.
+
+%% Client function: Mod.fn(pid, args...) -> gen_server:call/cast(pid, msg)
+gen_client_fn(L, FnName, Params, CallOrCast) ->
+    PidVar = {var, L, '__agent_pid__'},
+    ClientParams = [PidVar | Params],
+    Msg = agent_message(L, FnName, Params),
+    GsFn = case CallOrCast of call -> call; cast -> cast end,
+    {function, L, FnName, ClientParams,
+     [{dot_call, L, 'GenServer', GsFn, [PidVar, Msg]}]}.
+
+%% Build the message tuple/atom for gen_server call/cast
+agent_message(L, FnName, []) ->
+    {atom, L, FnName};
+agent_message(L, FnName, Params) ->
+    {tuple, L, [{atom, L, FnName} | Params]}.
+
+%% Build the pattern for matching the message in handle_call/handle_cast
+agent_message_pattern(L, FnName, []) ->
+    {pat_atom, L, FnName};
+agent_message_pattern(L, FnName, Params) ->
+    {pat_tuple, L, [{pat_atom, L, FnName} | params_to_patterns(Params)]}.
+
+params_to_patterns(Params) ->
+    [case P of
+         {var, PL, N} -> {var, PL, N};
+         {pat_wildcard, _} = W -> W;
+         {pat_var, _, _} = PV -> PV;
+         Other -> Other
+     end || P <- Params].
+
+%% Generate handle_call clause
+gen_handle_call(L, FnName, Params, Guard, Body) ->
+    MsgPat = agent_message_pattern(L, FnName, Params),
+    {RewrittenBody, _Counter} = rewrite_agent_body(Body, 0),
+    %% Extract last expression as reply value, wrap in {:reply, val, state}
+    WrappedBody = wrap_reply(L, RewrittenBody),
+    case Guard of
+        none ->
+            {function, L, handle_call,
+             [MsgPat, {var, L, '__from__'}, {var, L, '__agent_state__'}],
+             WrappedBody};
+        _ ->
+            {function_g, L, handle_call,
+             [MsgPat, {var, L, '__from__'}, {var, L, '__agent_state__'}],
+             Guard,
+             WrappedBody}
+    end.
+
+%% Generate handle_cast clause
+gen_handle_cast(L, FnName, Params, Body) ->
+    MsgPat = agent_message_pattern(L, FnName, Params),
+    {RewrittenBody, _Counter} = rewrite_agent_body(Body, 0),
+    %% Wrap in {:noreply, state}
+    WrappedBody = wrap_noreply(L, RewrittenBody),
+    {function, L, handle_cast,
+     [MsgPat, {var, L, '__agent_state__'}],
+     WrappedBody}.
+
+%% Wrap body: all exprs, then {:reply, last_value, __agent_state__}
+wrap_reply(L, []) ->
+    [{tuple, L, [{atom, L, reply}, {atom, L, nil}, {var, L, '__agent_state__'}]}];
+wrap_reply(L, Body) ->
+    {Init, Last} = split_last(Body),
+    Init ++ [
+        {assign, L, {var, L, '__agent_reply__'}, Last},
+        {tuple, L, [{atom, L, reply}, {var, L, '__agent_reply__'}, {var, L, '__agent_state__'}]}
+    ].
+
+%% Wrap body: all exprs, then {:noreply, __agent_state__}
+wrap_noreply(L, []) ->
+    [{tuple, L, [{atom, L, noreply}, {var, L, '__agent_state__'}]}];
+wrap_noreply(L, Body) ->
+    Body ++ [
+        {tuple, L, [{atom, L, noreply}, {var, L, '__agent_state__'}]}
+    ].
+
+split_last([X]) -> {[], X};
+split_last([H | T]) ->
+    {Rest, Last} = split_last(T),
+    {[H | Rest], Last}.
+
+%% ── Agent body rewriting ────────────────────────────────────────────────
+%% Rewrites @var reads and @var = expr writes in agent function bodies.
+
+rewrite_agent_body(Exprs, Counter) ->
+    {Rewritten, C1} = lists:mapfoldl(fun rewrite_agent_expr/2, Counter, Exprs),
+    {flatten_agent_body(Rewritten), C1}.
+
+rewrite_agent_expr({state_read, L, Name}, Counter) ->
+    {{field_access, L, {var, L, '__agent_state__'}, Name}, Counter};
+
+rewrite_agent_expr({state_write, L, Name, Expr}, Counter) ->
+    {RewrittenExpr, C1} = rewrite_agent_expr(Expr, Counter),
+    WVar = list_to_atom("__agent_w" ++ integer_to_list(C1) ++ "__"),
+    %% Expand to: __agent_wN__ = expr, __agent_state__ = Map.put(state, :name, wN), __agent_wN__
+    Nodes = [
+        {assign, L, {var, L, WVar}, RewrittenExpr},
+        {assign, L, {var, L, '__agent_state__'},
+            {dot_call, L, 'Map', put, [
+                {atom, L, Name},
+                {var, L, WVar},
+                {var, L, '__agent_state__'}
+            ]}},
+        {var, L, WVar}
+    ],
+    %% Return the sequence as a special multi-node marker
+    {{agent_write_seq, L, Nodes}, C1 + 1};
+
+%% Recurse into nested expressions
+rewrite_agent_expr({op, L, Op, Lhs, Rhs}, Counter) ->
+    {L2, C1} = rewrite_agent_expr(Lhs, Counter),
+    {R2, C2} = rewrite_agent_expr(Rhs, C1),
+    {{op, L, Op, L2, R2}, C2};
+rewrite_agent_expr({unary, L, Op, E}, Counter) ->
+    {E2, C1} = rewrite_agent_expr(E, Counter),
+    {{unary, L, Op, E2}, C1};
+rewrite_agent_expr({call, L, Fun, Args}, Counter) ->
+    {Args2, C1} = rewrite_agent_body(Args, Counter),
+    {{call, L, Fun, Args2}, C1};
+rewrite_agent_expr({dot_call, L, Mod, Fun, Args}, Counter) ->
+    {Args2, C1} = rewrite_agent_body(Args, Counter),
+    {{dot_call, L, Mod, Fun, Args2}, C1};
+rewrite_agent_expr({assign, L, Var, Expr}, Counter) ->
+    {E2, C1} = rewrite_agent_expr(Expr, Counter),
+    {{assign, L, Var, E2}, C1};
+rewrite_agent_expr({tuple, L, Elems}, Counter) ->
+    {E2, C1} = rewrite_agent_body(Elems, Counter),
+    {{tuple, L, E2}, C1};
+rewrite_agent_expr({list, L, Elems}, Counter) ->
+    {E2, C1} = rewrite_agent_body(Elems, Counter),
+    {{list, L, E2}, C1};
+rewrite_agent_expr({map, L, Pairs}, Counter) ->
+    {Vals, C1} = rewrite_agent_body([V || {_, V} <- Pairs], Counter),
+    Keys = [K || {K, _} <- Pairs],
+    {{map, L, lists:zip(Keys, Vals)}, C1};
+rewrite_agent_expr({if_expr, L, Cond, Then, Else}, Counter) ->
+    {Cond2, C1} = rewrite_agent_expr(Cond, Counter),
+    {Then2, C2} = rewrite_agent_body(Then, C1),
+    {Else2, C3} = rewrite_agent_body(Else, C2),
+    {{if_expr, L, Cond2, Then2, Else2}, C3};
+rewrite_agent_expr({block, L, Params, Body}, Counter) ->
+    {Body2, C1} = rewrite_agent_body(Body, Counter),
+    {{block, L, Params, Body2}, C1};
+rewrite_agent_expr(Other, Counter) ->
+    {Other, Counter}.
+
+%% Flatten agent_write_seq nodes into the body list
+flatten_agent_body(Exprs) ->
+    lists:flatmap(fun({agent_write_seq, _, Nodes}) -> Nodes;
+                     (Other) -> [Other]
+                  end, Exprs).
 
 %% ── Default parameter expansion ─────────────────────────────────────────
 %% Generates wrapper clauses for functions with default parameters.
@@ -321,6 +576,9 @@ expand_schema_def({schema_def, L, TableBin, Fields}, ModName) ->
      AllFn, FindFn, FindByFn, CreateFn, DeleteFn, CountFn].
 
 %% ── Function transformation ────────────────────────────────────────────────
+
+%% Pass through non-function nodes (e.g. behaviour_attr from agent desugaring)
+transform_function({behaviour_attr, _, _} = B) -> B;
 
 transform_function({function_g, Line, Name, Params, Guard, Body}) ->
     TransBody  = transform_seq(Body),

--- a/apps/winn/test/winn_agent_tests.erl
+++ b/apps/winn/test/winn_agent_tests.erl
@@ -1,0 +1,208 @@
+-module(winn_agent_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Helpers ────────────────────────────────────────────────────────────────
+
+compile_and_load(Source) ->
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    Filtered = winn_newline_filter:filter(Tokens),
+    {ok, AST} = winn_parser:parse(Filtered),
+    Transformed = winn_transform:transform(AST),
+    [CoreMod] = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% ── Basic agent: start, call, read ─────────────────────────────────────────
+
+basic_counter_test() ->
+    Mod = compile_and_load(
+        "agent BasicCounter\n"
+        "  state count = 0\n"
+        "  def increment()\n"
+        "    @count = @count + 1\n"
+        "  end\n"
+        "  def value()\n"
+        "    @count\n"
+        "  end\n"
+        "end\n"),
+    Pid = Mod:start(),
+    ?assert(is_pid(Pid)),
+    ?assertEqual(1, Mod:increment(Pid)),
+    ?assertEqual(2, Mod:increment(Pid)),
+    ?assertEqual(2, Mod:value(Pid)),
+    gen_server:stop(Pid).
+
+%% ── Agent with arguments ──────────────────────────────────────────────────
+
+agent_with_args_test() ->
+    Mod = compile_and_load(
+        "agent ArgCounter\n"
+        "  state count = 0\n"
+        "  def add(n)\n"
+        "    @count = @count + n\n"
+        "  end\n"
+        "  def value()\n"
+        "    @count\n"
+        "  end\n"
+        "end\n"),
+    Pid = Mod:start(),
+    ?assertEqual(5, Mod:add(Pid, 5)),
+    ?assertEqual(15, Mod:add(Pid, 10)),
+    ?assertEqual(15, Mod:value(Pid)),
+    gen_server:stop(Pid).
+
+%% ── Multiple state variables ──────────────────────────────────────────────
+
+multi_state_test() ->
+    Mod = compile_and_load(
+        "agent MultiState\n"
+        "  state x = 1\n"
+        "  state y = 2\n"
+        "  def sum()\n"
+        "    @x + @y\n"
+        "  end\n"
+        "  def set_x(val)\n"
+        "    @x = val\n"
+        "  end\n"
+        "  def set_y(val)\n"
+        "    @y = val\n"
+        "  end\n"
+        "end\n"),
+    Pid = Mod:start(),
+    ?assertEqual(3, Mod:sum(Pid)),
+    ?assertEqual(10, Mod:set_x(Pid, 10)),
+    ?assertEqual(12, Mod:sum(Pid)),
+    ?assertEqual(20, Mod:set_y(Pid, 20)),
+    ?assertEqual(30, Mod:sum(Pid)),
+    gen_server:stop(Pid).
+
+%% ── Start with overrides ──────────────────────────────────────────────────
+
+start_with_overrides_test() ->
+    Mod = compile_and_load(
+        "agent OverrideCounter\n"
+        "  state count = 0\n"
+        "  def value()\n"
+        "    @count\n"
+        "  end\n"
+        "end\n"),
+    %% Default start
+    Pid1 = Mod:start(),
+    ?assertEqual(0, Mod:value(Pid1)),
+    gen_server:stop(Pid1),
+    %% Start with override
+    Pid2 = Mod:start(#{count => 100}),
+    ?assertEqual(100, Mod:value(Pid2)),
+    gen_server:stop(Pid2).
+
+%% ── Async def (cast) ──────────────────────────────────────────────────────
+
+async_def_test() ->
+    Mod = compile_and_load(
+        "agent AsyncAgent\n"
+        "  state count = 0\n"
+        "  async def bump()\n"
+        "    @count = @count + 1\n"
+        "  end\n"
+        "  def value()\n"
+        "    @count\n"
+        "  end\n"
+        "end\n"),
+    Pid = Mod:start(),
+    ?assertEqual(ok, Mod:bump(Pid)),
+    %% Cast is async, give it a moment to process
+    timer:sleep(10),
+    ?assertEqual(1, Mod:value(Pid)),
+    gen_server:stop(Pid).
+
+%% ── State isolation between instances ─────────────────────────────────────
+
+state_isolation_test() ->
+    Mod = compile_and_load(
+        "agent IsoCounter\n"
+        "  state count = 0\n"
+        "  def increment()\n"
+        "    @count = @count + 1\n"
+        "  end\n"
+        "  def value()\n"
+        "    @count\n"
+        "  end\n"
+        "end\n"),
+    Pid1 = Mod:start(),
+    Pid2 = Mod:start(),
+    Mod:increment(Pid1),
+    Mod:increment(Pid1),
+    Mod:increment(Pid1),
+    Mod:increment(Pid2),
+    ?assertEqual(3, Mod:value(Pid1)),
+    ?assertEqual(1, Mod:value(Pid2)),
+    gen_server:stop(Pid1),
+    gen_server:stop(Pid2).
+
+%% ── Return values ─────────────────────────────────────────────────────────
+
+return_values_test() ->
+    Mod = compile_and_load(
+        "agent ReturnAgent\n"
+        "  state items = []\n"
+        "  def reset()\n"
+        "    @items = []\n"
+        "    :ok\n"
+        "  end\n"
+        "  def get_items()\n"
+        "    @items\n"
+        "  end\n"
+        "end\n"),
+    Pid = Mod:start(),
+    ?assertEqual(ok, Mod:reset(Pid)),
+    ?assertEqual([], Mod:get_items(Pid)),
+    gen_server:stop(Pid).
+
+%% ── Multiple writes in one function ───────────────────────────────────────
+
+multiple_writes_test() ->
+    Mod = compile_and_load(
+        "agent SwapAgent\n"
+        "  state a = 1\n"
+        "  state b = 2\n"
+        "  def swap()\n"
+        "    temp = @a\n"
+        "    @a = @b\n"
+        "    @b = temp\n"
+        "    :ok\n"
+        "  end\n"
+        "  def get_a()\n"
+        "    @a\n"
+        "  end\n"
+        "  def get_b()\n"
+        "    @b\n"
+        "  end\n"
+        "end\n"),
+    Pid = Mod:start(),
+    ?assertEqual(1, Mod:get_a(Pid)),
+    ?assertEqual(2, Mod:get_b(Pid)),
+    Mod:swap(Pid),
+    ?assertEqual(2, Mod:get_a(Pid)),
+    ?assertEqual(1, Mod:get_b(Pid)),
+    gen_server:stop(Pid).
+
+%% ── Agent with string state ──────────────────────────────────────────────
+
+string_state_test() ->
+    Mod = compile_and_load(
+        "agent Greeter\n"
+        "  state name = \"world\"\n"
+        "  def set_name(n)\n"
+        "    @name = n\n"
+        "  end\n"
+        "  def greet()\n"
+        "    @name\n"
+        "  end\n"
+        "end\n"),
+    Pid = Mod:start(),
+    ?assertEqual(<<"world">>, Mod:greet(Pid)),
+    Mod:set_name(Pid, <<"Alice">>),
+    ?assertEqual(<<"Alice">>, Mod:greet(Pid)),
+    gen_server:stop(Pid).


### PR DESCRIPTION
## Summary

Introduces the `agent` keyword as a first-class language construct for stateful actors. Compiles to GenServer under the hood with zero boilerplate.

Closes #102

## Syntax

```winn
agent Counter
  state count = 0

  def increment()
    @count = @count + 1
  end

  def value()
    @count
  end

  async def log_reset()
    @count = 0
  end
end

counter = Counter.start()
Counter.increment(counter)
IO.puts(Counter.value(counter))  # 1
```

## Key features

- `@state` syntax for reading/writing agent state
- `async def` for fire-and-forget (cast) operations
- `start()` with defaults or `start(%{count: 100})` with overrides
- Multi-clause pattern matching and guards supported
- Full desugaring in transform phase — no codegen changes needed

## Changes

| File | Change |
|------|--------|
| `winn_lexer.xrl` | `agent`, `async` keywords + `@ident` state_ref token |
| `winn_parser.yrl` | agent_def, state_decl, state_read/write, async productions |
| `winn_newline_filter.erl` | `agent` context tracking |
| `winn_transform.erl` | Full agent → module + GenServer desugaring |
| `winn_codegen.erl` | `resolve_dot_call('Agent', Fun)` |
| `winn_agent.erl` | **NEW** — stop helpers |
| `winn_agent_tests.erl` | **NEW** — 9 end-to-end tests |

## Test plan

- [x] 9 new agent tests pass
- [x] Full suite: 562 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)