### PR TITLE
Add release workflow to publish winn binary (#110)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   upload-binary:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  upload-binary:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Erlang/OTP
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27'
+          rebar3-version: '3.24'
+
+      - name: Restore rebar3 cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            _build
+            ~/.cache/rebar3
+          key: ${{ runner.os }}-rebar3-27-${{ hashFiles('rebar.lock', 'rebar.config', 'apps/**/*.yrl', 'apps/**/*.xrl') }}
+          restore-keys: |
+            ${{ runner.os }}-rebar3-27-
+
+      - name: Fetch dependencies
+        run: rebar3 get-deps
+
+      - name: Build escript
+        run: rebar3 escriptize
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: _build/default/bin/winn

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Winn Roadmap
 
-## Current Status — v0.7.0
+## Current Status — v0.8.1
 
-562 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics.
+Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics.
 
 ### What's Shipped
 
@@ -15,22 +15,12 @@
 | v0.5.0 | Production Readiness | Connection pooling, transactions, SQLite, model methods (`User.all`), migrations, generators (`winn create`), deployment |
 | v0.6.0 | Observability | Metrics module, live metrics dashboard (`winn metrics`), load testing (`winn bench`) |
 | v0.7.0 | Core Stdlib + Packages | File I/O, Regex, Timer, Retry, DateTime/String, package system (`winn add`/`winn remove`), [winn-redis](https://github.com/gregwinn/winn-redis), [winn-mongodb](https://github.com/gregwinn/winn-mongodb), [winn-amqp](https://github.com/gregwinn/winn-amqp) |
+| v0.8.0 | Web Framework + Agents | Static files, CORS, auth middleware, health checks, `agent` keyword with `@state` syntax and `async def`, compiles to GenServer |
+| v0.8.1 | Bug Fix | Fixed agent parser regression (stale committed `winn_parser.erl`); CI cache now busts on grammar changes |
 
 ---
 
 ## Coming Next
-
-### v0.8.0 — Web Framework + Agents
-
-| Issue | Feature | Description |
-|-------|---------|-------------|
-| [#47](https://github.com/gregwinn/winn-lang/issues/47) | Static files | Serve CSS/JS/images from a directory |
-| [#48](https://github.com/gregwinn/winn-lang/issues/48) | CORS | Built-in CORS middleware |
-| [#49](https://github.com/gregwinn/winn-lang/issues/49) | Sessions | Cookie and session support |
-| [#50](https://github.com/gregwinn/winn-lang/issues/50) | File uploads | Multipart form data parsing |
-| [#51](https://github.com/gregwinn/winn-lang/issues/51) | Auth middleware | Bearer token and session auth |
-| [#65](https://github.com/gregwinn/winn-lang/issues/65) | Health checks | `/healthz` and `/ready` for Kubernetes |
-| [#102](https://github.com/gregwinn/winn-lang/issues/102) | **`agent` keyword** | First-class stateful actors — `agent Counter` with `@state` syntax, `async def` for cast, compiles to GenServer |
 
 ### v0.9.0 — Developer Tooling
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,5 +58,7 @@ Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syn
 | Issue | Feature | Description |
 |-------|---------|-------------|
 | [#20](https://github.com/gregwinn/winn-lang/issues/20) | Example projects | Todo API, chat server, GitHub sync worker |
-| [#21](https://github.com/gregwinn/winn-lang/issues/21) | Package registry | `winn publish`, dependency resolution |
+| [#21](https://github.com/gregwinn/winn-lang/issues/21) | Package registry | Hosted Winn-native registry, `winn publish`, search, discovery |
 | [#101](https://github.com/gregwinn/winn-lang/issues/101) | Package registry v2 | Dependency resolution, lockfile, `winn search` |
+| [#110](https://github.com/gregwinn/winn-lang/issues/110) | curl installer | `curl -fsSL https://winn.ws/install.sh \| bash` — detect OS/arch, install pre-built binary |
+| [#111](https://github.com/gregwinn/winn-lang/issues/111) | apt + dnf packages | Native `.deb`/`.rpm` packages with hosted repos and GPG signing for Ubuntu and Fedora |


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — triggers on `release: published`, builds the escript with OTP 27, and uploads `_build/default/bin/winn` as a release asset.
- The winn escript is BEAM bytecode (platform-independent), so one binary works on all OS/arch as long as Erlang is installed.
- This is the prerequisite for the curl install script at `https://winn.ws/install.sh` (closes #110 in combination with the website change).

## How it works
1. User runs `curl -fsSL https://winn.ws/install.sh | bash`
2. Script checks Erlang/OTP >= 25 is installed
3. Fetches latest version tag from GitHub API
4. Downloads `https://github.com/gregwinn/winn-lang/releases/download/$VERSION/winn`
5. Installs to `~/.local/bin/winn`, checks PATH, verifies with `winn version`

## Test plan
- [ ] Merge and create a new release — verify the `winn` binary appears as a release asset
- [ ] Run `curl -fsSL https://winn.ws/install.sh | bash` on a fresh machine with Erlang installed
- [ ] Verify `winn version` works after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)