### PR TITLE
Reorganize generator output to Rails-style subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the Winn language are documented here.
 
+## [Unreleased]
+
+### Breaking Changes
+- **Generator paths reorganized** — `winn create` now outputs to Rails-style subdirectories. Existing projects must move files manually:
+  - Models: `src/*.winn` → `src/models/*.winn`
+  - Migrations: `migrations/` → `db/migrations/`
+  - Tasks: `tasks/` → `src/tasks/`
+  - Routers renamed to Controllers: `src/name.winn` → `src/controllers/name_controller.winn` (module `NameController`)
+
+### CLI
+- **`winn new`** — scaffold now creates `src/models/`, `src/controllers/`, `src/tasks/`, `test/`, `db/migrations/`, `config/`, and `db/seeds.winn`
+- **`winn create model`** — output path: `src/models/<name>.winn`
+- **`winn create migration`** — output path: `db/migrations/<timestamp>_<name>.winn`
+- **`winn create task`** — output path: `src/tasks/<name>.winn`
+- **`winn create router`** — output path: `src/controllers/<name>_controller.winn`, module `<Name>Controller`
+- **`winn create scaffold`** — model → `src/models/`, controller → `src/controllers/`, test → `test/`
+- **`winn migrate`** — reads migrations from `db/migrations/` (was `migrations/`)
+
+---
+
 ## [0.8.1] - 2026-04-03
 
 ### Fixes

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -249,13 +249,21 @@ scaffold(AppName) ->
     RebarFile = AppName ++ "/rebar.config",
     GitignoreFile = AppName ++ "/.gitignore",
     PackageFile = AppName ++ "/package.json",
+    SeedsFile = AppName ++ "/db/seeds.winn",
     try
         ok = file:make_dir(AppName),
         ok = file:make_dir(SrcDir),
+        ok = filelib:ensure_path(AppName ++ "/src/models"),
+        ok = filelib:ensure_path(AppName ++ "/src/controllers"),
+        ok = filelib:ensure_path(AppName ++ "/src/tasks"),
+        ok = filelib:ensure_path(AppName ++ "/test"),
+        ok = filelib:ensure_path(AppName ++ "/db/migrations"),
+        ok = filelib:ensure_path(AppName ++ "/config"),
         ok = file:write_file(WinnFile, starter_winn(AppName)),
         ok = file:write_file(RebarFile, starter_rebar(AppName)),
         ok = file:write_file(GitignoreFile, gitignore_content()),
         ok = file:write_file(PackageFile, starter_package_json(AppName)),
+        ok = file:write_file(SeedsFile, seeds_content()),
         ok
     catch
         error:{badmatch, {error, Reason}} ->
@@ -281,6 +289,9 @@ starter_rebar(AppName) ->
 
 gitignore_content() ->
     "_build/\nebin/\n*.beam\n_packages/\n".
+
+seeds_content() ->
+    "# db/seeds.winn\n# Seed your database here.\n\nmodule Seeds\n  def run()\n    IO.puts(\"Seeding database...\")\n  end\nend\n".
 
 starter_package_json(AppName) ->
     BaseName = filename:basename(AppName),

--- a/apps/winn/src/winn_generator.erl
+++ b/apps/winn/src/winn_generator.erl
@@ -11,7 +11,8 @@ generate(model, [Name | FieldArgs]) ->
     ModName = to_pascal(Name),
     TableName = to_snake(Name) ++ "s",
     Content = model_template(ModName, TableName, Fields),
-    Path = "src/" ++ to_snake(Name) ++ ".winn",
+    ok = filelib:ensure_path("src/models"),
+    Path = "src/models/" ++ to_snake(Name) ++ ".winn",
     write_file(Path, Content);
 
 generate(migration, [Name | FieldArgs]) ->
@@ -19,8 +20,8 @@ generate(migration, [Name | FieldArgs]) ->
     Timestamp = timestamp(),
     FileName = Timestamp ++ "_" ++ to_snake(Name),
     Content = migration_template(to_pascal(Name), Fields),
-    Path = "migrations/" ++ FileName ++ ".winn",
-    ok = filelib:ensure_path("migrations"),
+    Path = "db/migrations/" ++ FileName ++ ".winn",
+    ok = filelib:ensure_path("db/migrations"),
     write_file(Path, Content);
 
 generate(task, [Name]) ->
@@ -29,24 +30,26 @@ generate(task, [Name]) ->
     ModName = "Tasks." ++ lists:flatten(lists:join(".", ModParts)),
     FileName = lists:flatten(lists:join("_", Parts)),
     Content = task_template(ModName),
-    Path = "tasks/" ++ FileName ++ ".winn",
-    ok = filelib:ensure_path("tasks"),
+    Path = "src/tasks/" ++ FileName ++ ".winn",
+    ok = filelib:ensure_path("src/tasks"),
     write_file(Path, Content);
 
 generate(router, [Name]) ->
-    ModName = to_pascal(Name),
+    ModName = to_pascal(Name) ++ "Controller",
     Content = router_template(ModName),
-    Path = "src/" ++ to_snake(Name) ++ ".winn",
+    ok = filelib:ensure_path("src/controllers"),
+    Path = "src/controllers/" ++ to_snake(Name) ++ "_controller.winn",
     write_file(Path, Content);
 
 generate(scaffold, [Name | FieldArgs]) ->
-    Fields = parse_fields(FieldArgs),
+    _Fields = parse_fields(FieldArgs),
     %% Generate model
     generate(model, [Name | FieldArgs]),
-    %% Generate router
+    %% Generate controller
     ModName = to_pascal(Name),
     RouterContent = scaffold_router_template(ModName, to_snake(Name)),
-    RouterPath = "src/" ++ to_snake(Name) ++ "_router.winn",
+    ok = filelib:ensure_path("src/controllers"),
+    RouterPath = "src/controllers/" ++ to_snake(Name) ++ "_controller.winn",
     write_file(RouterPath, RouterContent),
     %% Generate test
     TestContent = scaffold_test_template(ModName),
@@ -151,7 +154,7 @@ router_template(ModName) ->
 
 scaffold_router_template(ModName, SnakeName) ->
     lists:flatten(io_lib:format(
-        "module ~sRouter~n"
+        "module ~sController~n"
         "  use Winn.Router~n"
         "~n"
         "  def routes()~n"

--- a/apps/winn/src/winn_migrate.erl
+++ b/apps/winn/src/winn_migrate.erl
@@ -1,12 +1,12 @@
 %% winn_migrate.erl
 %% Database migration runner.
-%% Discovers migrations in migrations/*.winn, tracks applied state
+%% Discovers migrations in db/migrations/*.winn, tracks applied state
 %% in a schema_migrations table, runs up/down in transactions.
 
 -module(winn_migrate).
 -export([migrate/1, rollback/1, status/0, ensure_migrations_table/0]).
 
--define(MIGRATIONS_DIR, "migrations").
+-define(MIGRATIONS_DIR, "db/migrations").
 -define(BUILD_DIR, "_build/migrations").
 
 %% ── Public API ───────────────────────────────────────────────────────────────

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,18 +116,27 @@ Generate code from templates. `winn c` is shorthand.
 
 ```sh
 winn create model User name:string email:string
+# => src/models/user.winn
+
 winn create migration CreateUsers name:string
+# => db/migrations/TIMESTAMP_create_users.winn
+
 winn create task db:seed
+# => src/tasks/db_seed.winn
+
 winn create router Api
+# => src/controllers/api_controller.winn  (module ApiController)
+
 winn create scaffold Post title:string body:text
+# => src/models/post.winn, src/controllers/post_controller.winn, test/post_test.winn
 ```
 
-Scaffold generates model + CRUD router + test file.
+Scaffold generates model + CRUD controller + test file.
 
 <a id="winn-migrate"></a>
 ### `winn migrate`
 
-Run pending database migrations from `migrations/*.winn`.
+Run pending database migrations from `db/migrations/*.winn`.
 
 ```sh
 winn migrate              # run all pending
@@ -155,7 +164,7 @@ winn task db:seed
 winn task db:migrate
 ```
 
-Tasks are modules with `use Winn.Task` and a `run/1` function in `tasks/` or `src/`.
+Tasks are modules with `use Winn.Task` and a `run/1` function in `src/tasks/`.
 
 <a id="winn-add"></a>
 ### `winn add <package>`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,10 +66,19 @@ This creates:
 
 ```
 my_app/
-├── rebar.config       # Erlang build config
+├── rebar.config           # Erlang build config
 ├── .gitignore
-└── src/
-    └── my_app.winn    # Your first Winn file
+├── package.json
+├── src/
+│   ├── my_app.winn        # Your first Winn file
+│   ├── models/
+│   ├── controllers/
+│   └── tasks/
+├── test/
+├── db/
+│   ├── migrations/
+│   └── seeds.winn
+└── config/
 ```
 
 The generated `src/my_app.winn`:
@@ -137,15 +146,23 @@ A typical Winn project looks like this:
 
 ```
 my_app/
-├── rebar.config           # Dependencies and build config
+├── rebar.config               # Dependencies and build config
 ├── .gitignore
+├── package.json
 ├── src/
-│   ├── my_app.winn        # Application entry point
-│   ├── router.winn        # HTTP routes
-│   ├── user.winn          # User schema
-│   └── auth.winn          # Authentication logic
-├── ebin/                  # Compiled .beam files (generated)
-└── config/                # Configuration files (optional)
+│   ├── my_app.winn            # Application entry point
+│   ├── models/
+│   │   └── user.winn          # User schema
+│   ├── controllers/
+│   │   └── api_controller.winn  # HTTP routes
+│   └── tasks/
+│       └── db_seed.winn       # Background tasks
+├── test/
+├── db/
+│   ├── migrations/            # Database migrations
+│   └── seeds.winn
+├── config/                    # Configuration files
+└── ebin/                      # Compiled .beam files (generated)
 ```
 
 ---
@@ -516,10 +533,20 @@ Scaffold models, migrations, tasks, and routers:
 
 ```sh
 winn create model User name:string email:string
+# => src/models/user.winn
+
 winn create migration CreateUsers name:string email:string
+# => db/migrations/TIMESTAMP_create_users.winn
+
 winn create task db:seed
+# => src/tasks/db_seed.winn
+
 winn create router Api
+# => src/controllers/api_controller.winn  (module ApiController)
+
 winn create scaffold Post title:string body:text
+# => src/models/post.winn, src/controllers/post_controller.winn, test/post_test.winn
+
 winn c model User   # shorthand
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,6 +29,7 @@ Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syn
 | [#52](https://github.com/gregwinn/winn-lang/issues/52) | Formatter | `winn fmt` for consistent code style |
 | [#53](https://github.com/gregwinn/winn-lang/issues/53) | Linter | `winn lint` for static analysis |
 | [#54](https://github.com/gregwinn/winn-lang/issues/54) | Scaffold | Improved `winn new` with test/, config/ |
+| [#114](https://github.com/gregwinn/winn-lang/issues/114) | Generator dirs | Rails-style subdirectories: `src/models/`, `src/controllers/`, `db/migrations/` |
 | [#55](https://github.com/gregwinn/winn-lang/issues/55) | LSP | Language server for IDE integration |
 | [#99](https://github.com/gregwinn/winn-lang/issues/99) | Codegen split | Split `winn_codegen.erl` into focused submodules |
 


### PR DESCRIPTION
## Summary

- `winn new` scaffold now creates organized subdirectories: `src/models/`, `src/controllers/`, `src/tasks/`, `test/`, `db/migrations/`, `config/`, and a `db/seeds.winn` stub
- All `winn create` generators output to their proper subdirectory (models, controllers, tasks, migrations)
- `winn create router` renamed to generate `*Controller` modules in `src/controllers/`
- `winn migrate` now discovers migrations in `db/migrations/` instead of `migrations/`
- Docs updated in `getting-started.md` and `cli.md`

## Breaking Changes

Existing projects must move files manually:
- `src/user.winn` → `src/models/user.winn`
- `migrations/` → `db/migrations/`
- `tasks/` → `src/tasks/`

## Test plan

- [ ] `winn new testapp` — verify all dirs exist (`src/models/`, `src/controllers/`, `src/tasks/`, `test/`, `db/migrations/`, `config/`, `db/seeds.winn`)
- [ ] `winn create model User name:string` — creates `src/models/user.winn`
- [ ] `winn create migration CreateUsers name:string` — creates `db/migrations/TIMESTAMP_create_users.winn`
- [ ] `winn create task db:seed` — creates `src/tasks/db_seed.winn`
- [ ] `winn create router Posts` — creates `src/controllers/posts_controller.winn` with module `PostsController`
- [ ] `winn create scaffold Product name:string` — creates in `src/models/`, `src/controllers/`, `test/`
- [ ] `rebar3 eunit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)