### PR TITLE
Add code formatter — winn fmt (#52)

### DIFF
--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -89,6 +89,12 @@ main(Args) ->
         {rollback, RollbackArgs} ->
             run_rollback(RollbackArgs);
 
+        {fmt, FmtArgs} ->
+            run_fmt(FmtArgs);
+
+        {fmt_check, FmtArgs} ->
+            run_fmt_check(FmtArgs);
+
         {deps, Sub} ->
             Result = run_deps(Sub),
             case Result of
@@ -134,6 +140,12 @@ parse_args(["metrics" | Args])     -> {metrics, Args};
 parse_args(["release" | Args])     -> {release, Args};
 parse_args(["migrate" | Args])     -> {migrate, Args};
 parse_args(["rollback" | Args])    -> {rollback, Args};
+parse_args(["fmt"])                 -> {fmt, []};
+parse_args(["fmt" | Args])         ->
+    case lists:member("--check", Args) of
+        true  -> {fmt_check, Args -- ["--check"]};
+        false -> {fmt, Args}
+    end;
 parse_args(["deps" | Sub])         -> {deps, Sub};
 parse_args(["version" | _])        -> version;
 parse_args(["-v" | _])             -> version;
@@ -733,6 +745,65 @@ find_doc_files([]) ->
 find_doc_files(Paths) ->
     lists:filter(fun filelib:is_file/1, Paths).
 
+%% ── Formatter ───────────────────────────────────────────────────────────
+
+run_fmt([]) ->
+    Files = find_winn_files(),
+    case Files of
+        [] ->
+            io:format("No .winn files found in src/ or current directory.~n"),
+            halt(0);
+        _ ->
+            lists:foreach(fun(F) ->
+                case winn_formatter:format_file(F) of
+                    {ok, Formatted} ->
+                        file:write_file(F, Formatted),
+                        io:format("  formatted  ~s~n", [F]);
+                    {error, Reason} ->
+                        io:format("  error      ~s: ~p~n", [F, Reason])
+                end
+            end, Files),
+            halt(0)
+    end;
+run_fmt(Files) ->
+    lists:foreach(fun(F) ->
+        case winn_formatter:format_file(F) of
+            {ok, Formatted} ->
+                file:write_file(F, Formatted),
+                io:format("  formatted  ~s~n", [F]);
+            {error, Reason} ->
+                io:format("  error      ~s: ~p~n", [F, Reason])
+        end
+    end, Files),
+    halt(0).
+
+run_fmt_check([]) ->
+    run_fmt_check(find_winn_files());
+run_fmt_check(Files) ->
+    Changed = lists:filtermap(fun(F) ->
+        case winn_formatter:check_file(F) of
+            ok -> false;
+            {changed, _} ->
+                io:format("  unformatted  ~s~n", [F]),
+                {true, F}
+        end
+    end, Files),
+    case Changed of
+        [] ->
+            io:format("All files formatted.~n"),
+            halt(0);
+        _ ->
+            io:format("~B file(s) need formatting. Run `winn fmt` to fix.~n", [length(Changed)]),
+            halt(1)
+    end.
+
+find_winn_files() ->
+    SrcFiles = filelib:wildcard("src/*.winn"),
+    case SrcFiles of
+        [] -> filelib:wildcard("*.winn");
+        _  -> SrcFiles
+    end.
+
 %% ── Deps subcommand ─────────────────────────────────────────────────────
 
 run_deps(["list"])              -> winn_deps:list();
@@ -785,6 +856,9 @@ print_usage() ->
         "  winn start <module>     Start with a specific module~n"
         "  winn test               Run all tests in test/~n"
         "  winn test <file>        Run a specific test file~n"
+        "  winn fmt                Format all .winn files in place~n"
+        "  winn fmt <file>         Format a specific file~n"
+        "  winn fmt --check        Check formatting without changing (CI)~n"
         "  winn docs               Generate API docs with dependency graph~n"
         "  winn docs <file>        Generate docs for a single file~n"
         "  winn watch              Watch files and hot-reload with live dashboard~n"

--- a/apps/winn/src/winn_comment.erl
+++ b/apps/winn/src/winn_comment.erl
@@ -1,0 +1,122 @@
+%% winn_comment.erl
+%% Extract comments from Winn source code with line numbers.
+%% Scans raw source text (not tokens) so comments are preserved
+%% even though the lexer discards them.
+
+-module(winn_comment).
+-export([extract/1]).
+
+%% extract(Source) -> [{Line, Text, Type}]
+%%   Line = integer() — 1-based line number
+%%   Text = string()  — the comment text including # prefix
+%%   Type = line | block
+extract(Source) when is_list(Source) ->
+    scan(Source, 1, normal, [], []).
+
+%% State machine: normal | in_string | in_triple_string | in_block_comment
+%% Args: Chars, Line, State, CurrentComment, Acc
+
+%% End of input
+scan([], _Line, _State, [], Acc) ->
+    lists:reverse(Acc);
+scan([], Line, in_block_comment, Cur, Acc) ->
+    Text = lists:reverse(Cur),
+    lists:reverse([{Line, Text, block} | Acc]);
+scan([], _Line, _State, _Cur, Acc) ->
+    lists:reverse(Acc);
+
+%% === Normal state ===
+
+%% Triple-quoted string start
+scan([$", $", $" | Rest], Line, normal, Cur, Acc) ->
+    scan(Rest, Line, in_triple_string, Cur, Acc);
+%% Regular string start
+scan([$" | Rest], Line, normal, Cur, Acc) ->
+    scan(Rest, Line, in_string, Cur, Acc);
+%% Block comment start: #|
+scan([$#, $| | Rest], Line, normal, _Cur, Acc) ->
+    scan(Rest, Line, in_block_comment, [$|, $#], Acc);
+%% Line comment: # (not followed by |)
+scan([$# | Rest], Line, normal, _Cur, Acc) ->
+    {CommentText, Remaining} = collect_line_comment([$# | Rest]),
+    scan(Remaining, Line, normal, [], [{Line, CommentText, line} | Acc]);
+%% Newline in normal
+scan([$\n | Rest], Line, normal, Cur, Acc) ->
+    scan(Rest, Line + 1, normal, Cur, Acc);
+%% Any other char in normal
+scan([_ | Rest], Line, normal, Cur, Acc) ->
+    scan(Rest, Line, normal, Cur, Acc);
+
+%% === In regular string ===
+
+%% Escaped char in string — skip both
+scan([$\\, _ | Rest], Line, in_string, Cur, Acc) ->
+    scan(Rest, Line, in_string, Cur, Acc);
+%% String interpolation start #{
+scan([$#, ${ | Rest], Line, in_string, Cur, Acc) ->
+    {Remaining, NewLine} = skip_interp(Rest, Line, 0),
+    scan(Remaining, NewLine, in_string, Cur, Acc);
+%% End of string
+scan([$" | Rest], Line, in_string, Cur, Acc) ->
+    scan(Rest, Line, normal, Cur, Acc);
+%% Newline in string
+scan([$\n | Rest], Line, in_string, Cur, Acc) ->
+    scan(Rest, Line + 1, in_string, Cur, Acc);
+%% Any char in string
+scan([_ | Rest], Line, in_string, Cur, Acc) ->
+    scan(Rest, Line, in_string, Cur, Acc);
+
+%% === In triple-quoted string ===
+
+%% End of triple string
+scan([$", $", $" | Rest], Line, in_triple_string, Cur, Acc) ->
+    scan(Rest, Line, normal, Cur, Acc);
+%% Newline in triple string
+scan([$\n | Rest], Line, in_triple_string, Cur, Acc) ->
+    scan(Rest, Line + 1, in_triple_string, Cur, Acc);
+%% Any char in triple string
+scan([_ | Rest], Line, in_triple_string, Cur, Acc) ->
+    scan(Rest, Line, in_triple_string, Cur, Acc);
+
+%% === In block comment ===
+
+%% End of block comment: |#
+scan([$|, $# | Rest], Line, in_block_comment, Cur, Acc) ->
+    Text = lists:reverse([$#, $| | Cur]),
+    StartLine = Line - count_newlines_in(Text),
+    scan(Rest, Line, normal, [], [{StartLine, Text, block} | Acc]);
+%% Newline in block comment
+scan([$\n | Rest], Line, in_block_comment, Cur, Acc) ->
+    scan(Rest, Line + 1, in_block_comment, [$\n | Cur], Acc);
+%% Any char in block comment
+scan([C | Rest], Line, in_block_comment, Cur, Acc) ->
+    scan(Rest, Line, in_block_comment, [C | Cur], Acc).
+
+%% === Helpers ===
+
+collect_line_comment(Chars) ->
+    collect_line_comment(Chars, []).
+
+collect_line_comment([], Acc) ->
+    {lists:reverse(Acc), []};
+collect_line_comment([$\n | Rest], Acc) ->
+    {lists:reverse(Acc), [$\n | Rest]};
+collect_line_comment([C | Rest], Acc) ->
+    collect_line_comment(Rest, [C | Acc]).
+
+%% Skip through interpolation #{...} handling nested braces
+skip_interp([$} | Rest], Line, 0) ->
+    {Rest, Line};
+skip_interp([${ | Rest], Line, Depth) ->
+    skip_interp(Rest, Line, Depth + 1);
+skip_interp([$} | Rest], Line, Depth) ->
+    skip_interp(Rest, Line, Depth - 1);
+skip_interp([$\n | Rest], Line, Depth) ->
+    skip_interp(Rest, Line + 1, Depth);
+skip_interp([_ | Rest], Line, Depth) ->
+    skip_interp(Rest, Line, Depth);
+skip_interp([], Line, _Depth) ->
+    {[], Line}.
+
+count_newlines_in(Str) ->
+    length([C || C <- Str, C =:= $\n]).

--- a/apps/winn/src/winn_formatter.erl
+++ b/apps/winn/src/winn_formatter.erl
@@ -1,0 +1,590 @@
+%% winn_formatter.erl
+%% Code formatter for Winn source files.
+%% Parses source → AST, then pretty-prints back to canonical form
+%% with comments reinserted by line proximity.
+
+-module(winn_formatter).
+-export([format_string/1, format_file/1, check_file/1]).
+
+%% ── Public API ──────────────────────────────────────────────────────────────
+
+format_string(Source) when is_list(Source) ->
+    Comments = winn_comment:extract(Source),
+    case parse(Source) of
+        {ok, AST} ->
+            Formatted = format_ast(AST, Comments),
+            {ok, Formatted};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+format_file(Path) ->
+    case file:read_file(Path) of
+        {ok, Bin} ->
+            format_string(binary_to_list(Bin));
+        {error, Reason} ->
+            {error, {read_error, Reason}}
+    end.
+
+check_file(Path) ->
+    case file:read_file(Path) of
+        {ok, Bin} ->
+            Source = binary_to_list(Bin),
+            case format_string(Source) of
+                {ok, Formatted} ->
+                    case Formatted =:= Source of
+                        true  -> ok;
+                        false -> {changed, Path}
+                    end;
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, {read_error, Reason}}
+    end.
+
+%% ── Parse (lexer → parser only, no transform/codegen) ───────────────────────
+
+parse(Source) ->
+    case winn_lexer:string(Source) of
+        {ok, RawTokens, _} ->
+            Tokens = winn_newline_filter:filter(RawTokens),
+            case winn_parser:parse(Tokens) of
+                {ok, AST} -> {ok, AST};
+                {error, Reason} -> {error, {parse_error, Reason}}
+            end;
+        {error, Reason, _} ->
+            {error, {lex_error, Reason}}
+    end.
+
+%% ── Format AST with comment reinsertion ─────────────────────────────────────
+
+format_ast(TopForms, Comments) ->
+    {Lines, _LastLine} = format_top_forms(TopForms, 0),
+    Merged = merge_comments(Lines, Comments),
+    ensure_trailing_newline(lists:flatten(Merged)).
+
+format_top_forms([], _Indent) ->
+    {[], 0};
+format_top_forms(Forms, Indent) ->
+    format_top_forms(Forms, Indent, []).
+
+format_top_forms([], _Indent, Acc) ->
+    Lines = lists:reverse(Acc),
+    LastLine = case Lines of
+        [] -> 0;
+        _ -> element(1, lists:last(Lines))
+    end,
+    {Lines, LastLine};
+format_top_forms([Form | Rest], Indent, Acc) ->
+    FormLines = format_node(Form, Indent),
+    Separator = case Rest of
+        [] -> [];
+        _  -> [{0, ""}]
+    end,
+    format_top_forms(Rest, Indent, lists:reverse(FormLines ++ Separator) ++ Acc).
+
+%% ── Node formatting ─────────────────────────────────────────────────────────
+%% format_node(Node, Indent) -> [{OrigLine, String}]
+
+%% Module
+format_node({module, Line, Name, Body}, Indent) ->
+    Header = [{Line, pad(Indent) ++ "module " ++ format_module_name(Name)}],
+    BodyLines = format_body(Body, Indent + 2),
+    Footer = [{Line, pad(Indent) ++ "end"}],
+    Header ++ BodyLines ++ Footer;
+
+%% Agent
+format_node({agent, Line, Name, Body}, Indent) ->
+    Header = [{Line, pad(Indent) ++ "agent " ++ format_module_name(Name)}],
+    BodyLines = format_agent_body(Body, Indent + 2),
+    Footer = [{Line, pad(Indent) ++ "end"}],
+    Header ++ BodyLines ++ Footer;
+
+%% Function
+format_node({function, Line, Name, Params, Body}, Indent) ->
+    Sig = pad(Indent) ++ "def " ++ atom_to_list(Name) ++ "(" ++ format_params(Params) ++ ")",
+    BodyLines = format_expr_seq(Body, Indent + 2),
+    [{Line, Sig}] ++ BodyLines ++ [{Line, pad(Indent) ++ "end"}];
+
+%% Function with guard
+format_node({function_g, Line, Name, Params, Guard, Body}, Indent) ->
+    Sig = pad(Indent) ++ "def " ++ atom_to_list(Name) ++ "(" ++ format_params(Params) ++ ")"
+        ++ " when " ++ format_expr(Guard, Indent + 2),
+    BodyLines = format_expr_seq(Body, Indent + 2),
+    [{Line, Sig}] ++ BodyLines ++ [{Line, pad(Indent) ++ "end"}];
+
+%% Agent sync function
+format_node({agent_fn, Line, Name, Params, Body}, Indent) ->
+    Sig = pad(Indent) ++ "def " ++ atom_to_list(Name) ++ "(" ++ format_params(Params) ++ ")",
+    BodyLines = format_expr_seq(Body, Indent + 2),
+    [{Line, Sig}] ++ BodyLines ++ [{Line, pad(Indent) ++ "end"}];
+
+%% Agent sync function with guard
+format_node({agent_fn_g, Line, Name, Params, Guard, Body}, Indent) ->
+    Sig = pad(Indent) ++ "def " ++ atom_to_list(Name) ++ "(" ++ format_params(Params) ++ ")"
+        ++ " when " ++ format_expr(Guard, Indent + 2),
+    BodyLines = format_expr_seq(Body, Indent + 2),
+    [{Line, Sig}] ++ BodyLines ++ [{Line, pad(Indent) ++ "end"}];
+
+%% Agent cast (async) function
+format_node({agent_cast_fn, Line, Name, Params, Body}, Indent) ->
+    Sig = pad(Indent) ++ "async def " ++ atom_to_list(Name) ++ "(" ++ format_params(Params) ++ ")",
+    BodyLines = format_expr_seq(Body, Indent + 2),
+    [{Line, Sig}] ++ BodyLines ++ [{Line, pad(Indent) ++ "end"}];
+
+%% Agent state declaration
+format_node({state_decl, Line, Name, Expr}, Indent) ->
+    [{Line, pad(Indent) ++ "state " ++ atom_to_list(Name) ++ " = " ++ format_expr(Expr, Indent)}];
+
+%% Use directive
+format_node({use_directive, Line, Mod1, Mod2}, Indent) ->
+    [{Line, pad(Indent) ++ "use " ++ format_module_name(Mod1) ++ "." ++ format_module_name(Mod2)}];
+
+%% Import directive
+format_node({import_directive, Line, ModName}, Indent) ->
+    [{Line, pad(Indent) ++ "import " ++ format_module_name(ModName)}];
+
+%% Alias directive
+format_node({alias_directive, Line, Mod1, Mod2}, Indent) ->
+    [{Line, pad(Indent) ++ "alias " ++ format_module_name(Mod1) ++ "." ++ format_module_name(Mod2)}];
+
+%% Schema definition
+format_node({schema_def, Line, TableName, Fields}, Indent) ->
+    Header = [{Line, pad(Indent) ++ "schema \"" ++ binary_to_list(TableName) ++ "\" do"}],
+    FieldLines = lists:flatmap(fun(F) -> format_field(F, Indent + 2) end, Fields),
+    Footer = [{Line, pad(Indent) ++ "end"}],
+    Header ++ FieldLines ++ Footer;
+
+%% Struct definition
+format_node({struct_def, Line, Fields}, Indent) ->
+    FieldStrs = [[$: | atom_to_list(F)] || F <- Fields],
+    [{Line, pad(Indent) ++ "struct [" ++ string:join(FieldStrs, ", ") ++ "]"}];
+
+%% Protocol definition
+format_node({protocol_def, Line, Fns}, Indent) ->
+    Header = [{Line, pad(Indent) ++ "protocol do"}],
+    FnLines = format_body(Fns, Indent + 2),
+    Footer = [{Line, pad(Indent) ++ "end"}],
+    Header ++ FnLines ++ Footer;
+
+%% Impl definition
+format_node({impl_def, Line, ModName, Fns}, Indent) ->
+    Header = [{Line, pad(Indent) ++ "impl " ++ format_module_name(ModName) ++ " do"}],
+    FnLines = format_body(Fns, Indent + 2),
+    Footer = [{Line, pad(Indent) ++ "end"}],
+    Header ++ FnLines ++ Footer;
+
+%% Expression nodes — delegate to format_expr and wrap in a line
+format_node(Expr, Indent) ->
+    Line = node_line(Expr),
+    [{Line, pad(Indent) ++ format_expr(Expr, Indent)}].
+
+%% ── Body formatting (with blank lines between items) ────────────────────────
+
+format_body(Items, Indent) ->
+    format_body(Items, Indent, []).
+
+format_body([], _Indent, Acc) ->
+    lists:reverse(Acc);
+format_body([Item | Rest], Indent, Acc) ->
+    ItemLines = format_node(Item, Indent),
+    Separator = case Rest of
+        [] -> [];
+        _  -> [{0, ""}]
+    end,
+    format_body(Rest, Indent, lists:reverse(ItemLines ++ Separator) ++ Acc).
+
+%% Agent body (state decls + functions)
+format_agent_body(Items, Indent) ->
+    format_agent_body(Items, Indent, []).
+
+format_agent_body([], _Indent, Acc) ->
+    lists:reverse(Acc);
+format_agent_body([Item | Rest], Indent, Acc) ->
+    ItemLines = format_node(Item, Indent),
+    Separator = case Rest of
+        [] -> [];
+        _  -> [{0, ""}]
+    end,
+    format_agent_body(Rest, Indent, lists:reverse(ItemLines ++ Separator) ++ Acc).
+
+%% ── Expression sequence ─────────────────────────────────────────────────────
+
+format_expr_seq(Exprs, Indent) ->
+    lists:flatmap(fun(E) ->
+        Line = node_line(E),
+        [{Line, pad(Indent) ++ format_expr(E, Indent)}]
+    end, Exprs).
+
+%% ── Expression formatting ───────────────────────────────────────────────────
+%% format_expr(Node, Indent) -> string()
+%% Indent is the current indentation level, used for multi-line constructs.
+
+%% Pipe — flatten and format as chain
+format_expr({pipe, _L, _Lhs, _Rhs} = Pipe, Indent) ->
+    [First | Stages] = flatten_pipe(Pipe),
+    FirstStr = format_expr(First, Indent),
+    PipeIndent = pad(Indent + 2),
+    StageStrs = [PipeIndent ++ "|> " ++ format_expr(S, Indent + 2) || S <- Stages],
+    string:join([FirstStr | StageStrs], "\n");
+
+%% Binary operators
+format_expr({op, _L, Op, Lhs, Rhs}, Indent) ->
+    LStr = maybe_paren(Lhs, Op, left, Indent),
+    RStr = maybe_paren(Rhs, Op, right, Indent),
+    LStr ++ " " ++ atom_to_list(Op) ++ " " ++ RStr;
+
+%% Unary operators
+format_expr({unary, _L, '-', Expr}, Indent) ->
+    "-" ++ format_expr(Expr, Indent);
+format_expr({unary, _L, 'not', Expr}, Indent) ->
+    "not " ++ format_expr(Expr, Indent);
+
+%% Range
+format_expr({range, _L, From, To}, Indent) ->
+    format_expr(From, Indent) ++ ".." ++ format_expr(To, Indent);
+
+%% Assignment
+format_expr({assign, _L, {var, _, Name}, Expr}, Indent) ->
+    atom_to_list(Name) ++ " = " ++ format_expr(Expr, Indent);
+
+%% Pattern assignment
+format_expr({pat_assign, _L, Pattern, Expr}, Indent) ->
+    format_pattern(Pattern) ++ " = " ++ format_expr(Expr, Indent);
+
+%% State read/write
+format_expr({state_read, _L, Name}, _Indent) ->
+    "@" ++ atom_to_list(Name);
+format_expr({state_write, _L, Name, Expr}, Indent) ->
+    "@" ++ atom_to_list(Name) ++ " = " ++ format_expr(Expr, Indent);
+
+%% Field access
+format_expr({field_access, _L, Obj, Field}, Indent) ->
+    format_expr(Obj, Indent) ++ "." ++ atom_to_list(Field);
+
+%% Local call
+format_expr({call, _L, Fun, Args}, Indent) ->
+    atom_to_list(Fun) ++ "(" ++ format_args(Args, Indent) ++ ")";
+
+%% Dot call
+format_expr({dot_call, _L, Mod, Fun, Args}, Indent) ->
+    format_module_name(Mod) ++ "." ++ atom_to_list(Fun) ++ "(" ++ format_args(Args, Indent) ++ ")";
+
+%% Block call
+format_expr({block_call, _L, Call, Params, Body}, Indent) ->
+    CallStr = format_expr(Call, Indent),
+    ParamStr = case Params of
+        [] -> "";
+        _  -> " |" ++ string:join([atom_to_list(N) || {var, _, N} <- Params], ", ") ++ "|"
+    end,
+    BodyIndent = Indent + 2,
+    case Body of
+        [Single] ->
+            CallStr ++ " do" ++ ParamStr ++ " " ++ format_expr(Single, BodyIndent) ++ " end";
+        Multi ->
+            CallStr ++ " do" ++ ParamStr ++ "\n"
+            ++ lists:flatten([
+                pad(BodyIndent) ++ format_expr(E, BodyIndent) ++ "\n" || E <- Multi
+            ])
+            ++ pad(Indent) ++ "end"
+    end;
+
+%% If/else
+format_expr({if_expr, _L, Cond, Then, []}, Indent) ->
+    "if " ++ format_expr(Cond, Indent) ++ "\n"
+    ++ format_indented_seq(Then, Indent + 2)
+    ++ pad(Indent) ++ "end";
+format_expr({if_expr, _L, Cond, Then, Else}, Indent) ->
+    "if " ++ format_expr(Cond, Indent) ++ "\n"
+    ++ format_indented_seq(Then, Indent + 2)
+    ++ pad(Indent) ++ "else\n"
+    ++ format_indented_seq(Else, Indent + 2)
+    ++ pad(Indent) ++ "end";
+
+%% Switch
+format_expr({switch_expr, _L, Scrutinee, Clauses}, Indent) ->
+    "switch " ++ format_expr(Scrutinee, Indent) ++ "\n"
+    ++ lists:flatten([format_switch_clause(C, Indent + 2) || C <- Clauses])
+    ++ pad(Indent) ++ "end";
+
+%% Match block
+format_expr({match_block, _L, none, Clauses}, Indent) ->
+    "match\n"
+    ++ lists:flatten([format_match_clause(C, Indent + 2) || C <- Clauses])
+    ++ pad(Indent) ++ "end";
+format_expr({match_block, _L, Scrutinee, Clauses}, Indent) ->
+    "match " ++ format_expr(Scrutinee, Indent) ++ "\n"
+    ++ lists:flatten([format_match_clause(C, Indent + 2) || C <- Clauses])
+    ++ pad(Indent) ++ "end";
+
+%% Try/rescue
+format_expr({try_expr, _L, Body, Rescues}, Indent) ->
+    "try\n"
+    ++ format_indented_seq(Body, Indent + 2)
+    ++ pad(Indent) ++ "rescue\n"
+    ++ lists:flatten([format_rescue_clause(C, Indent + 2) || C <- Rescues])
+    ++ pad(Indent) ++ "end";
+
+%% For comprehension
+format_expr({for_expr, _L, Var, Iter, Body}, Indent) ->
+    "for " ++ atom_to_list(Var) ++ " in " ++ format_expr(Iter, Indent) ++ " do\n"
+    ++ format_indented_seq(Body, Indent + 2)
+    ++ pad(Indent) ++ "end";
+
+%% Anonymous function (lambda)
+format_expr({block, _L, Params, Body}, Indent) ->
+    ParamStr = format_params(Params),
+    case Body of
+        [Single] ->
+            "fn(" ++ ParamStr ++ ") => " ++ format_expr(Single, Indent) ++ " end";
+        Multi ->
+            "fn(" ++ ParamStr ++ ") =>\n"
+            ++ format_indented_seq(Multi, Indent + 2)
+            ++ pad(Indent) ++ "end"
+    end;
+
+%% Variables
+format_expr({var, _L, Name}, _Indent) ->
+    atom_to_list(Name);
+
+%% Atom — could be a module name (PascalCase) or atom literal (:foo)
+format_expr({atom, _L, Name}, _Indent) ->
+    Str = atom_to_list(Name),
+    case Str of
+        [C | _] when C >= $A, C =< $Z -> format_module_name(Name);
+        _ -> ":" ++ Str
+    end;
+
+%% Literals
+format_expr({integer, _L, Val}, _Indent) ->
+    integer_to_list(Val);
+format_expr({float, _L, Val}, _Indent) ->
+    float_to_list(Val, [{decimals, 10}, compact]);
+format_expr({string, _L, Val}, _Indent) when is_binary(Val) ->
+    "\"" ++ escape_string(binary_to_list(Val)) ++ "\"";
+format_expr({boolean, _L, true}, _Indent) ->
+    "true";
+format_expr({boolean, _L, false}, _Indent) ->
+    "false";
+format_expr({nil, _L}, _Indent) ->
+    "nil";
+
+%% Interpolated string
+format_expr({interp_string, _L, Parts}, _Indent) ->
+    "\"" ++ lists:flatten([format_interp_part(P) || P <- Parts]) ++ "\"";
+
+%% List
+format_expr({list, _L, Elems}, Indent) ->
+    "[" ++ format_args(Elems, Indent) ++ "]";
+
+%% Tuple
+format_expr({tuple, _L, Elems}, Indent) ->
+    "{" ++ format_args(Elems, Indent) ++ "}";
+
+%% Map
+format_expr({map, _L, []}, _Indent) ->
+    "%{}";
+format_expr({map, _L, Pairs}, Indent) ->
+    PairStrs = [format_map_pair(P, Indent) || P <- Pairs],
+    "%{" ++ string:join(PairStrs, ", ") ++ "}";
+
+%% Catch-all
+format_expr(Other, _Indent) ->
+    lists:flatten(io_lib:format("~p", [Other])).
+
+%% ── Helpers ─────────────────────────────────────────────────────────────────
+
+format_module_name(Name) when is_atom(Name) ->
+    Raw = atom_to_list(Name),
+    case lists:member($., Raw) of
+        true ->
+            Parts = string:split(Raw, ".", all),
+            string:join([capitalize(P) || P <- Parts], ".");
+        false ->
+            capitalize(Raw)
+    end.
+
+capitalize([]) -> [];
+capitalize([C | Rest]) when C >= $a, C =< $z -> [C - 32 | Rest];
+capitalize(S) -> S.
+
+format_params(Params) ->
+    string:join([format_pattern(P) || P <- Params], ", ").
+
+format_args(Args, Indent) ->
+    string:join([format_expr(A, Indent) || A <- Args], ", ").
+
+format_pattern({var, _L, Name}) ->
+    atom_to_list(Name);
+format_pattern({pat_wildcard, _L}) ->
+    "_";
+format_pattern({pat_atom, _L, true}) ->
+    "true";
+format_pattern({pat_atom, _L, false}) ->
+    "false";
+format_pattern({pat_atom, _L, nil}) ->
+    "nil";
+format_pattern({pat_atom, _L, Val}) ->
+    ":" ++ atom_to_list(Val);
+format_pattern({pat_integer, _L, Val}) ->
+    integer_to_list(Val);
+format_pattern({pat_tuple, _L, Elems}) ->
+    "{" ++ string:join([format_pattern(E) || E <- Elems], ", ") ++ "}";
+format_pattern({pat_list, _L, Elems, nil}) ->
+    "[" ++ string:join([format_pattern(E) || E <- Elems], ", ") ++ "]";
+format_pattern({pat_list, _L, Elems, Tail}) ->
+    "[" ++ string:join([format_pattern(E) || E <- Elems], ", ")
+    ++ " | " ++ format_pattern(Tail) ++ "]";
+format_pattern({default_param, _L, Name, Val}) ->
+    atom_to_list(Name) ++ " = " ++ format_expr(Val, 0);
+format_pattern({tuple, _L, Elems}) ->
+    "{" ++ string:join([format_pattern(E) || E <- Elems], ", ") ++ "}";
+format_pattern({atom, _L, Val}) ->
+    ":" ++ atom_to_list(Val);
+format_pattern({integer, _L, Val}) ->
+    integer_to_list(Val);
+format_pattern({boolean, _L, Val}) ->
+    atom_to_list(Val);
+format_pattern(Other) ->
+    format_expr(Other, 0).
+
+format_map_pair({Key, Val}, Indent) ->
+    atom_to_list(Key) ++ ": " ++ format_expr(Val, Indent).
+
+format_interp_part({str, Bin}) when is_binary(Bin) ->
+    escape_string(binary_to_list(Bin));
+format_interp_part({expr, ExprStr}) when is_list(ExprStr) ->
+    "#{" ++ ExprStr ++ "}".
+
+format_switch_clause({switch_clause, _L, Pattern, none, Body}, Indent) ->
+    case Body of
+        [Single] ->
+            pad(Indent) ++ format_pattern(Pattern) ++ " => " ++ format_expr(Single, Indent) ++ "\n";
+        Multi ->
+            pad(Indent) ++ format_pattern(Pattern) ++ " => do\n"
+            ++ format_indented_seq(Multi, Indent + 2)
+            ++ pad(Indent) ++ "end\n"
+    end;
+format_switch_clause({switch_clause, _L, Pattern, Guard, Body}, Indent) ->
+    GuardStr = " when " ++ format_expr(Guard, Indent),
+    case Body of
+        [Single] ->
+            pad(Indent) ++ format_pattern(Pattern) ++ GuardStr ++ " => " ++ format_expr(Single, Indent) ++ "\n";
+        Multi ->
+            pad(Indent) ++ format_pattern(Pattern) ++ GuardStr ++ " => do\n"
+            ++ format_indented_seq(Multi, Indent + 2)
+            ++ pad(Indent) ++ "end\n"
+    end.
+
+format_match_clause({match_clause, _L, Tag, Pattern, Body}, Indent) ->
+    TagStr = atom_to_list(Tag),
+    case Body of
+        [Single] ->
+            pad(Indent) ++ TagStr ++ " " ++ format_pattern(Pattern) ++ " => " ++ format_expr(Single, Indent) ++ "\n";
+        Multi ->
+            pad(Indent) ++ TagStr ++ " " ++ format_pattern(Pattern) ++ " =>\n"
+            ++ format_indented_seq(Multi, Indent + 2)
+    end.
+
+format_rescue_clause({rescue_clause, _L, Pattern, Body}, Indent) ->
+    case Body of
+        [Single] ->
+            pad(Indent) ++ format_pattern(Pattern) ++ " => " ++ format_expr(Single, Indent) ++ "\n";
+        Multi ->
+            pad(Indent) ++ format_pattern(Pattern) ++ " => do\n"
+            ++ format_indented_seq(Multi, Indent + 2)
+            ++ pad(Indent) ++ "end\n"
+    end.
+
+format_indented_seq(Exprs, Indent) ->
+    lists:flatten([pad(Indent) ++ format_expr(E, Indent) ++ "\n" || E <- Exprs]).
+
+format_field({field, Line, Name, Type}, Indent) ->
+    [{Line, pad(Indent) ++ "field :" ++ atom_to_list(Name) ++ ", :" ++ atom_to_list(Type)}].
+
+%% ── Pipe flattening ─────────────────────────────────────────────────────────
+
+flatten_pipe({pipe, _L, Lhs, Rhs}) ->
+    flatten_pipe(Lhs) ++ [Rhs];
+flatten_pipe(Other) ->
+    [Other].
+
+%% ── Operator precedence for parenthesization ────────────────────────────────
+
+precedence('|>') -> 1;
+precedence('or') -> 2;
+precedence('and') -> 3;
+precedence('==') -> 4;
+precedence('!=') -> 4;
+precedence('<') -> 4;
+precedence('>') -> 4;
+precedence('<=') -> 4;
+precedence('>=') -> 4;
+precedence('+') -> 5;
+precedence('-') -> 5;
+precedence('<>') -> 5;
+precedence('*') -> 6;
+precedence('/') -> 6;
+precedence(_) -> 99.
+
+maybe_paren({op, _, ChildOp, _, _} = Expr, ParentOp, _Side, Indent) ->
+    case precedence(ChildOp) < precedence(ParentOp) of
+        true  -> "(" ++ format_expr(Expr, Indent) ++ ")";
+        false -> format_expr(Expr, Indent)
+    end;
+maybe_paren(Expr, _ParentOp, _Side, Indent) ->
+    format_expr(Expr, Indent).
+
+%% ── Comment merging ─────────────────────────────────────────────────────────
+
+merge_comments(CodeLines, []) ->
+    [Text ++ "\n" || {_L, Text} <- CodeLines];
+merge_comments(CodeLines, Comments) ->
+    merge_comments(CodeLines, lists:keysort(1, Comments), []).
+
+merge_comments([], [], Acc) ->
+    lists:reverse(Acc);
+merge_comments([], [{_CLine, CText, _Type} | RestC], Acc) ->
+    merge_comments([], RestC, [CText ++ "\n" | Acc]);
+merge_comments([{CodeLine, Text} | RestCode], Comments, Acc) ->
+    {Before, After} = lists:partition(
+        fun({CLine, _CText, _Type}) -> CLine < CodeLine andalso CodeLine > 0 end,
+        Comments
+    ),
+    Ind = count_leading_spaces(Text),
+    CommentLines = [pad(Ind) ++ CText ++ "\n" || {_CL, CText, _CT} <- Before],
+    merge_comments(RestCode, After, [Text ++ "\n" | CommentLines] ++ Acc);
+merge_comments([], Comments, Acc) ->
+    Remaining = [CText ++ "\n" || {_CL, CText, _CT} <- Comments],
+    lists:reverse(Acc) ++ Remaining.
+
+count_leading_spaces([$\s | Rest]) -> 1 + count_leading_spaces(Rest);
+count_leading_spaces(_) -> 0.
+
+%% ── Utility ─────────────────────────────────────────────────────────────────
+
+pad(0) -> "";
+pad(N) when N > 0 -> lists:duplicate(N, $\s).
+
+escape_string([]) -> [];
+escape_string([$\n | Rest]) -> "\\n" ++ escape_string(Rest);
+escape_string([$\t | Rest]) -> "\\t" ++ escape_string(Rest);
+escape_string([$\r | Rest]) -> "\\r" ++ escape_string(Rest);
+escape_string([$\\ | Rest]) -> "\\\\" ++ escape_string(Rest);
+escape_string([$" | Rest]) -> "\\\"" ++ escape_string(Rest);
+escape_string([C | Rest]) -> [C | escape_string(Rest)].
+
+node_line({_, L, _}) when is_integer(L) -> L;
+node_line({_, L, _, _}) when is_integer(L) -> L;
+node_line({_, L, _, _, _}) when is_integer(L) -> L;
+node_line({_, L, _, _, _, _}) when is_integer(L) -> L;
+node_line({_, L}) when is_integer(L) -> L;
+node_line(_) -> 0.
+
+ensure_trailing_newline([]) -> "\n";
+ensure_trailing_newline(Str) ->
+    case lists:last(Str) of
+        $\n -> Str;
+        _   -> Str ++ "\n"
+    end.

--- a/apps/winn/test/winn_formatter_tests.erl
+++ b/apps/winn/test/winn_formatter_tests.erl
@@ -1,0 +1,308 @@
+%% winn_formatter_tests.erl — EUnit tests for winn fmt.
+
+-module(winn_formatter_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ── Helpers ──────────────────────────────────────────────────────────────
+
+fmt(Source) ->
+    {ok, Result} = winn_formatter:format_string(Source),
+    Result.
+
+%% ── Basic formatting ────────────────────────────────────────────────────
+
+hello_world_test() ->
+    Source = "module Hello\n  def main()\n    IO.puts(\"Hello, World!\")\n  end\nend\n",
+    ?assertEqual(Source, fmt(Source)).
+
+trailing_newline_test() ->
+    Source = "module Foo\n  def bar()\n    42\n  end\nend",
+    Result = fmt(Source),
+    ?assertEqual($\n, lists:last(Result)).
+
+%% ── Indentation normalization ───────────────────────────────────────────
+
+fix_indent_test() ->
+    Bad = "module Foo\ndef bar()\n1\nend\nend\n",
+    Expected = "module Foo\n  def bar()\n    1\n  end\nend\n",
+    ?assertEqual(Expected, fmt(Bad)).
+
+%% ── Blank lines between functions ───────────────────────────────────────
+
+blank_lines_between_functions_test() ->
+    Source = "module Foo\ndef bar()\n1\nend\ndef baz()\n2\nend\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "end\n\n  def baz") =/= nomatch).
+
+%% ── Operator spacing ────────────────────────────────────────────────────
+
+operator_spacing_test() ->
+    Source = "module Foo\n  def bar()\n    1 + 2\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "1 + 2") =/= nomatch).
+
+comparison_operators_test() ->
+    Source = "module Foo\n  def bar(x)\n    x == 1\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "x == 1") =/= nomatch).
+
+string_concat_test() ->
+    Source = "module Foo\n  def bar()\n    \"a\" <> \"b\"\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "\"a\" <> \"b\"") =/= nomatch).
+
+%% ── Pipe chain alignment ────────────────────────────────────────────────
+
+pipe_chain_test() ->
+    Source = "module Foo\n  def bar()\n    [1, 2, 3]\n      |> Enum.map() do |x| x * 2 end\n      |> IO.puts()\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "      |> Enum.map") =/= nomatch),
+    ?assert(string:find(Result, "      |> IO.puts") =/= nomatch).
+
+%% ── Idempotency ─────────────────────────────────────────────────────────
+
+idempotent_simple_test() ->
+    Source = "module Foo\n  def bar()\n    42\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+idempotent_complex_test() ->
+    Source = "module Svc\n  def fetch(id)\n    try\n      match HTTP.get(id)\n        ok r => {:ok, r}\n        err e => {:error, e}\n      end\n    rescue\n      _ => {:error, :fail}\n    end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+%% ── Comment preservation ────────────────────────────────────────────────
+
+line_comment_test() ->
+    Source = "module Foo\n  # A helper function\n  def bar()\n    42\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "# A helper function") =/= nomatch).
+
+multiple_comments_test() ->
+    Source = "module Foo\n  # First\n  def bar()\n    42\n  end\n\n  # Second\n  def baz()\n    99\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "# First") =/= nomatch),
+    ?assert(string:find(Result, "# Second") =/= nomatch).
+
+%% ── Guard functions ─────────────────────────────────────────────────────
+
+guard_function_test() ->
+    Source = "module Foo\n  def bar(n) when n > 0\n    n\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "def bar(n) when n > 0") =/= nomatch).
+
+%% ── Pattern matching ────────────────────────────────────────────────────
+
+pattern_params_test() ->
+    Source = "module Foo\n  def bar(0)\n    :zero\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "def bar(0)") =/= nomatch).
+
+tuple_pattern_test() ->
+    Source = "module Foo\n  def bar({:ok, val})\n    val\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "def bar({:ok, val})") =/= nomatch).
+
+%% ── If/else ─────────────────────────────────────────────────────────────
+
+if_else_test() ->
+    Source = "module Foo\n  def bar(x)\n    if x > 0\n      :pos\n    else\n      :neg\n    end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+if_no_else_test() ->
+    Source = "module Foo\n  def bar(x)\n    if x > 0\n      :pos\n    end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+%% ── Switch ──────────────────────────────────────────────────────────────
+
+switch_test() ->
+    Source = "module Foo\n  def bar(x)\n    switch x\n      0 => :zero\n      1 => :one\n      _ => :other\n    end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+%% ── Match block ─────────────────────────────────────────────────────────
+
+match_block_test() ->
+    Source = "module Foo\n  def bar()\n    match get()\n      ok val => val\n      err _ => nil\n    end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+%% ── Try/rescue ──────────────────────────────────────────────────────────
+
+try_rescue_test() ->
+    Source = "module Foo\n  def bar()\n    try\n      risky()\n    rescue\n      _ => :error\n    end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+%% ── For comprehension ───────────────────────────────────────────────────
+
+for_test() ->
+    Source = "module Foo\n  def bar()\n    for x in [1, 2, 3] do\n      x * 2\n    end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+%% ── Anonymous function ──────────────────────────────────────────────────
+
+lambda_test() ->
+    Source = "module Foo\n  def bar()\n    fn(x) => x + 1 end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+%% ── Block call ──────────────────────────────────────────────────────────
+
+block_call_single_test() ->
+    Source = "module Foo\n  def bar()\n    Enum.map([1, 2]) do |x| x * 2 end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+block_call_multi_test() ->
+    Source = "module Foo\n  def bar()\n    Enum.each([1, 2]) do |x|\n      IO.puts(x)\n    end\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2).
+
+%% ── Literals ────────────────────────────────────────────────────────────
+
+map_literal_test() ->
+    Source = "module Foo\n  def bar()\n    %{name: \"Greg\", age: 30}\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "%{name: \"Greg\", age: 30}") =/= nomatch).
+
+list_literal_test() ->
+    Source = "module Foo\n  def bar()\n    [1, 2, 3]\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "[1, 2, 3]") =/= nomatch).
+
+tuple_literal_test() ->
+    Source = "module Foo\n  def bar()\n    {:ok, 42}\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "{:ok, 42}") =/= nomatch).
+
+range_test() ->
+    Source = "module Foo\n  def bar()\n    1..10\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "1..10") =/= nomatch).
+
+nil_test() ->
+    Source = "module Foo\n  def bar()\n    nil\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "nil") =/= nomatch).
+
+boolean_test() ->
+    Source = "module Foo\n  def bar()\n    true\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "true") =/= nomatch).
+
+%% ── Interpolated string ─────────────────────────────────────────────────
+
+interp_string_test() ->
+    Source = "module Foo\n  def bar(name)\n    \"hello #{name}\"\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "\"hello #{name}\"") =/= nomatch).
+
+%% ── Assignment ──────────────────────────────────────────────────────────
+
+assign_test() ->
+    Source = "module Foo\n  def bar()\n    x = 42\n    x\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "x = 42") =/= nomatch).
+
+%% ── Directives ──────────────────────────────────────────────────────────
+
+use_directive_test() ->
+    Source = "module Foo\n  use Winn.Schema\n\n  def bar()\n    42\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "use Winn.Schema") =/= nomatch).
+
+import_directive_test() ->
+    Source = "module Foo\n  import HTTP\n\n  def bar()\n    42\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "import HTTP") =/= nomatch).
+
+%% ── Agent ───────────────────────────────────────────────────────────────
+
+agent_test() ->
+    Source = "agent Counter\n  state count = 0\n\n  def value()\n    @count\n  end\n\n  async def increment()\n    @count = @count + 1\n  end\nend\n",
+    R1 = fmt(Source),
+    R2 = fmt(R1),
+    ?assertEqual(R1, R2),
+    ?assert(string:find(R1, "agent Counter") =/= nomatch),
+    ?assert(string:find(R1, "state count = 0") =/= nomatch),
+    ?assert(string:find(R1, "@count") =/= nomatch),
+    ?assert(string:find(R1, "async def increment") =/= nomatch).
+
+%% ── Struct ──────────────────────────────────────────────────────────────
+
+struct_test() ->
+    Source = "module Foo\n  struct [:name, :age]\n\n  def bar()\n    42\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "struct [:name, :age]") =/= nomatch).
+
+%% ── Default params ──────────────────────────────────────────────────────
+
+default_param_test() ->
+    Source = "module Foo\n  def bar(x = 10)\n    x\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "def bar(x = 10)") =/= nomatch).
+
+%% ── Unary operators ─────────────────────────────────────────────────────
+
+unary_minus_test() ->
+    Source = "module Foo\n  def bar()\n    -1\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "-1") =/= nomatch).
+
+unary_not_test() ->
+    Source = "module Foo\n  def bar(x)\n    not x\n  end\nend\n",
+    Result = fmt(Source),
+    ?assert(string:find(Result, "not x") =/= nomatch).
+
+%% ── Check mode ──────────────────────────────────────────────────────────
+
+check_formatted_test() ->
+    Source = "module Foo\n  def bar()\n    42\n  end\nend\n",
+    TmpFile = "/tmp/winn_fmt_test_ok.winn",
+    ok = file:write_file(TmpFile, Source),
+    ?assertEqual(ok, winn_formatter:check_file(TmpFile)),
+    file:delete(TmpFile).
+
+check_unformatted_test() ->
+    Source = "module Foo\ndef bar()\n42\nend\nend\n",
+    TmpFile = "/tmp/winn_fmt_test_bad.winn",
+    ok = file:write_file(TmpFile, Source),
+    ?assertMatch({changed, _}, winn_formatter:check_file(TmpFile)),
+    file:delete(TmpFile).
+
+%% ── Example file round-trips ────────────────────────────────────────────
+
+example_hello_idempotent_test() ->
+    {ok, R1} = winn_formatter:format_file("examples/hello.winn"),
+    {ok, R2} = winn_formatter:format_string(R1),
+    ?assertEqual(R1, R2).
+
+example_fibonacci_idempotent_test() ->
+    {ok, R1} = winn_formatter:format_file("examples/fibonacci.winn"),
+    {ok, R2} = winn_formatter:format_string(R1),
+    ?assertEqual(R1, R2).
+
+example_web_service_idempotent_test() ->
+    {ok, R1} = winn_formatter:format_file("examples/web_service.winn"),
+    {ok, R2} = winn_formatter:format_string(R1),
+    ?assertEqual(R1, R2).
+
+example_pipeline_idempotent_test() ->
+    {ok, R1} = winn_formatter:format_file("examples/pipeline.winn"),
+    {ok, R2} = winn_formatter:format_string(R1),
+    ?assertEqual(R1, R2).


### PR DESCRIPTION
## Summary
- Adds `winn fmt` command for automatic code formatting of `.winn` source files
- Parses source → AST → pretty-prints back to canonical form with 2-space indentation, operator spacing, pipe alignment, and trailing newlines
- Preserves comments via line-proximity reinsertion (no lexer changes needed)
- Adds `--check` flag for CI integration (exits 1 if files need formatting)

## New files
| File | Purpose |
|------|---------|
| `winn_comment.erl` | Extracts `#` and `#\| \|#` comments from raw source with line numbers |
| `winn_formatter.erl` | Core formatter: lex → parse → pretty-print all AST node types |
| `winn_formatter_tests.erl` | 45 EUnit tests (idempotency, indentation, operators, pipes, comments, control flow, agents, example round-trips) |

## Usage
```sh
winn fmt                  # Format all src/*.winn in place
winn fmt src/app.winn     # Format a specific file
winn fmt --check          # CI — exit 1 if any file is unformatted
```

## Test plan
- [x] 45 new formatter-specific tests passing
- [x] Full suite: 607 tests, 0 failures
- [x] All 8 example files format idempotently
- [x] CLI `winn fmt` and `winn fmt --check` verified manually
- [ ] Review formatted output of a real project

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)