### PR TITLE
Fix generator tests and rename CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: "eunit (OTP ${{ matrix.otp }})"
     runs-on: ubuntu-latest
 
     strategy:

--- a/apps/winn/test/winn_generator_tests.erl
+++ b/apps/winn/test/winn_generator_tests.erl
@@ -6,43 +6,43 @@
 
 %% ── CLI parse args ──────────────────────────────────────────────────────────
 
-parse_create_model_test() ->
+parse_create_model_args_test() ->
     ?assertEqual({create, ["model", "User", "name:string"]},
                  winn_cli:parse_args(["create", "model", "User", "name:string"])).
 
-parse_c_shorthand_test() ->
+parse_c_shorthand_maps_to_create_test() ->
     ?assertEqual({create, ["model", "User"]},
                  winn_cli:parse_args(["c", "model", "User"])).
 
-parse_create_scaffold_test() ->
+parse_create_scaffold_with_fields_test() ->
     ?assertEqual({create, ["scaffold", "Post", "title:string", "body:text"]},
                  winn_cli:parse_args(["create", "scaffold", "Post", "title:string", "body:text"])).
 
 %% ── Field parsing ───────────────────────────────────────────────────────────
 
-parse_fields_test() ->
+parse_fields_splits_colon_pairs_test() ->
     ?assertEqual([{"name", "string"}, {"age", "integer"}],
                  winn_generator:parse_fields(["name:string", "age:integer"])).
 
-parse_fields_empty_test() ->
+parse_fields_returns_empty_for_no_args_test() ->
     ?assertEqual([], winn_generator:parse_fields([])).
 
-parse_fields_invalid_test() ->
+parse_fields_skips_args_without_colon_test() ->
     ?assertEqual([{"name", "string"}],
                  winn_generator:parse_fields(["name:string", "invalid"])).
 
 %% ── Model generator ────────────────────────────────────────────────────────
 
-model_generates_file_test() ->
+model_generates_schema_file_in_models_dir_test() ->
     %% Generate in a temp directory
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    ok = filelib:ensure_path(TmpDir ++ "/src/models"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(model, ["User", "name:string", "email:string"]),
 
-    {ok, Content} = file:read_file("src/user.winn"),
+    {ok, Content} = file:read_file("src/models/user.winn"),
     ?assert(binary:match(Content, <<"module User">>) =/= nomatch),
     ?assert(binary:match(Content, <<"use Winn.Schema">>) =/= nomatch),
     ?assert(binary:match(Content, <<"schema \"users\"">>) =/= nomatch),
@@ -55,15 +55,15 @@ model_generates_file_test() ->
 
 %% ── Task generator ─────────────────────────────────────────────────────────
 
-task_generates_file_test() ->
+task_generates_file_in_tasks_dir_test() ->
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir),
+    ok = filelib:ensure_path(TmpDir ++ "/src/tasks"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(task, ["db:seed"]),
 
-    {ok, Content} = file:read_file("tasks/db_seed.winn"),
+    {ok, Content} = file:read_file("src/tasks/db_seed.winn"),
     ?assert(binary:match(Content, <<"module Tasks.Db.Seed">>) =/= nomatch),
     ?assert(binary:match(Content, <<"use Winn.Task">>) =/= nomatch),
     ?assert(binary:match(Content, <<"def run(args)">>) =/= nomatch),
@@ -73,16 +73,16 @@ task_generates_file_test() ->
 
 %% ── Router generator ───────────────────────────────────────────────────────
 
-router_generates_file_test() ->
+router_generates_controller_in_controllers_dir_test() ->
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    ok = filelib:ensure_path(TmpDir ++ "/src/controllers"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(router, ["Api"]),
 
-    {ok, Content} = file:read_file("src/api.winn"),
-    ?assert(binary:match(Content, <<"module Api">>) =/= nomatch),
+    {ok, Content} = file:read_file("src/controllers/api_controller.winn"),
+    ?assert(binary:match(Content, <<"module ApiController">>) =/= nomatch),
     ?assert(binary:match(Content, <<"use Winn.Router">>) =/= nomatch),
     ?assert(binary:match(Content, <<"def routes()">>) =/= nomatch),
 
@@ -91,15 +91,15 @@ router_generates_file_test() ->
 
 %% ── Migration generator ────────────────────────────────────────────────────
 
-migration_generates_file_test() ->
+migration_generates_timestamped_file_in_db_dir_test() ->
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir),
+    ok = filelib:ensure_path(TmpDir ++ "/db/migrations"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(migration, ["CreateUsers", "name:string", "email:string"]),
 
-    Files = filelib:wildcard("migrations/*.winn"),
+    Files = filelib:wildcard("db/migrations/*.winn"),
     ?assertEqual(1, length(Files)),
     {ok, Content} = file:read_file(hd(Files)),
     ?assert(binary:match(Content, <<"module Migrations.CreateUsers">>) =/= nomatch),
@@ -111,21 +111,23 @@ migration_generates_file_test() ->
 
 %% ── Scaffold generator ─────────────────────────────────────────────────────
 
-scaffold_generates_files_test() ->
+scaffold_generates_model_controller_and_test_test() ->
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    ok = filelib:ensure_path(TmpDir ++ "/src/models"),
+    ok = filelib:ensure_path(TmpDir ++ "/src/controllers"),
+    ok = filelib:ensure_path(TmpDir ++ "/test"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(scaffold, ["Post", "title:string", "body:text"]),
 
-    ?assert(filelib:is_file("src/post.winn")),
-    ?assert(filelib:is_file("src/post_router.winn")),
+    ?assert(filelib:is_file("src/models/post.winn")),
+    ?assert(filelib:is_file("src/controllers/post_controller.winn")),
     ?assert(filelib:is_file("test/post_test.winn")),
 
-    {ok, RouterContent} = file:read_file("src/post_router.winn"),
-    ?assert(binary:match(RouterContent, <<"PostRouter">>) =/= nomatch),
-    ?assert(binary:match(RouterContent, <<"Post.all()">>) =/= nomatch),
+    {ok, ControllerContent} = file:read_file("src/controllers/post_controller.winn"),
+    ?assert(binary:match(ControllerContent, <<"PostController">>) =/= nomatch),
+    ?assert(binary:match(ControllerContent, <<"Post.all()">>) =/= nomatch),
 
     file:set_cwd(element(2, OldDir)),
     os:cmd("rm -rf " ++ TmpDir).


### PR DESCRIPTION
## Summary
- Fix all 6 failing `winn_generator_tests` by updating expected file paths and module names to match current generator output (e.g. `src/user.winn` → `src/models/user.winn`, `migrations/` → `db/migrations/`)
- Rename CI matrix jobs from "test (27)" / "test (28)" to "eunit (OTP 27)" / "eunit (OTP 28)" for clarity
- Rename test functions to be descriptive of what they verify (e.g. `model_generates_file_test` → `model_generates_schema_file_in_models_dir_test`)

## Test plan
- [ ] CI passes on both OTP 27 and OTP 28
- [ ] All 6 previously failing generator tests now pass
- [ ] CI job names display as "eunit (OTP 27)" and "eunit (OTP 28)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)