### PR TITLE
LSP Phase 1: lint diagnostics + didClose cleanup (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Winn language are documented here.
 
+## [Unreleased]
+
+### Developer Tooling
+- **LSP Phase 1 — lint diagnostics** — `winn lsp` now publishes lint warnings alongside compile errors. Each warning carries its rule name (e.g. `function_name_convention`) in the `code` field so editors can group and filter rules. Closing a document clears its diagnostics and removes it from the in-memory buffer. (#118)
+
 ## [0.9.0] - 2026-04-09
 
 ### Breaking Changes

--- a/apps/winn/src/winn_lsp.erl
+++ b/apps/winn/src/winn_lsp.erl
@@ -84,8 +84,10 @@ handle_message(#{<<"method">> := <<"textDocument/didSave">>, <<"params">> := Par
     publish_diagnostics(Uri, Text),
     maps:put(Uri, Text, State);
 
-handle_message(#{<<"method">> := <<"textDocument/didClose">>}, State) ->
-    State;
+handle_message(#{<<"method">> := <<"textDocument/didClose">>, <<"params">> := Params}, State) ->
+    #{<<"textDocument">> := #{<<"uri">> := Uri}} = Params,
+    publish_empty_diagnostics(Uri),
+    maps:remove(Uri, State);
 
 handle_message(#{<<"method">> := <<"textDocument/completion">>, <<"id">> := Id,
                  <<"params">> := Params}, State) ->
@@ -107,7 +109,12 @@ handle_message(_, State) ->
 
 publish_diagnostics(Uri, Text) ->
     Source = binary_to_list(Text),
-    Diagnostics = compile_for_diagnostics(Source),
+    publish(Uri, compile_for_diagnostics(Source)).
+
+publish_empty_diagnostics(Uri) ->
+    publish(Uri, []).
+
+publish(Uri, Diagnostics) ->
     Notification = #{
         <<"jsonrpc">> => <<"2.0">>,
         <<"method">> => <<"textDocument/publishDiagnostics">>,
@@ -125,7 +132,7 @@ compile_for_diagnostics(Source) ->
                 Tokens = winn_newline_filter:filter(RawTokens),
                 case winn_parser:parse(Tokens) of
                     {ok, Forms} ->
-                        case winn_semantic:analyse(Forms) of
+                        SemDiags = case winn_semantic:analyse(Forms) of
                             {ok, Analysed} ->
                                 try
                                     _Transformed = winn_transform:transform(Analysed),
@@ -138,7 +145,8 @@ compile_for_diagnostics(Source) ->
                             {error, Errors} ->
                                 [make_diagnostic(L, unicode:characters_to_binary(M), severity(S))
                                  || {S, L, _Name, M} <- Errors]
-                        end;
+                        end,
+                        SemDiags ++ lint_diagnostics(Source);
                     {error, {Line, winn_parser, Msg}} ->
                         [make_diagnostic(Line, format_parse_error(Msg), 1)]
                 end;
@@ -150,6 +158,22 @@ compile_for_diagnostics(Source) ->
     catch
         _:_ -> []
     end.
+
+%% Run the linter and convert each warning to an LSP diagnostic.
+%% Only invoked when parsing succeeded, so lint will parse cleanly too.
+lint_diagnostics(Source) ->
+    try winn_lint:check_string(Source) of
+        {ok, Violations} ->
+            [make_lint_diagnostic(V) || V <- Violations];
+        {error, _} ->
+            []
+    catch
+        _:_ -> []
+    end.
+
+make_lint_diagnostic({Sev, Line, Rule, Msg}) ->
+    Base = make_diagnostic(Line, ensure_binary(Msg), severity(Sev)),
+    Base#{<<"code">> => atom_to_binary(Rule, utf8)}.
 
 make_diagnostic(Line, Message, Severity) ->
     L = case Line of

--- a/apps/winn/test/winn_lsp_tests.erl
+++ b/apps/winn/test/winn_lsp_tests.erl
@@ -47,3 +47,33 @@ diagnostic_range_test() ->
 empty_source_test() ->
     Diags = winn_lsp:compile_for_diagnostics(""),
     ?assertEqual([], Diags).
+
+%% ── Lint warnings surface as diagnostics ─────────────────────────────────
+
+lint_warning_test() ->
+    %% camelCase function name trips function_name_convention
+    Source = "module Lintme\n  def badName()\n    IO.puts(\"hi\")\n  end\nend\n",
+    Diags = winn_lsp:compile_for_diagnostics(Source),
+    Warnings = [D || D <- Diags, maps:get(<<"severity">>, D) =:= 2],
+    ?assert(length(Warnings) >= 1),
+    [W | _] = Warnings,
+    ?assertEqual(<<"function_name_convention">>, maps:get(<<"code">>, W)),
+    ?assertEqual(<<"winn">>, maps:get(<<"source">>, W)).
+
+lint_warning_cleared_when_fixed_test() ->
+    Source = "module Lintme\n  def good_name()\n    IO.puts(\"hi\")\n  end\nend\n",
+    Diags = winn_lsp:compile_for_diagnostics(Source),
+    Warnings = [D || D <- Diags,
+                     maps:get(<<"severity">>, D) =:= 2,
+                     maps:get(<<"code">>, D, undefined) =:= <<"function_name_convention">>],
+    ?assertEqual([], Warnings).
+
+%% Lint should not be invoked when parsing fails (no spurious lint errors).
+lint_skipped_on_parse_error_test() ->
+    Source = "module Bad\n  def main()\n    end end\n  end\nend\n",
+    Diags = winn_lsp:compile_for_diagnostics(Source),
+    %% All diagnostics should be parse errors (severity 1, no code field)
+    ?assert(lists:all(fun(D) ->
+        maps:get(<<"severity">>, D) =:= 1
+            andalso not maps:is_key(<<"code">>, D)
+    end, Diags)).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -277,7 +277,7 @@ winn lsp   # starts language server on stdio
 
 **Capabilities:**
 
-- **Diagnostics** — inline compile errors from lexer, parser, semantic, and transform phases. Triggered on file open, change, and save.
+- **Diagnostics** — inline compile errors from lexer, parser, semantic, and transform phases, plus lint warnings from `winn lint` (each warning carries its rule name in the LSP `code` field). Triggered on file open, change, and save; cleared on close.
 - **Autocomplete** — dot-triggered completions for 14 modules: IO, String, Enum, List, Map, Server, HTTP, JSON, Logger, File, Repo, System, Task, Regex, Agent.
 
 **VS Code integration:** In the [Winn VS Code extension](https://marketplace.visualstudio.com/items?itemName=gregwinn.language-winn-vscode), set `"winn.lsp.command": "winn lsp"`.


### PR DESCRIPTION
## Summary
- Wire `winn_lint:check_string/1` into `winn_lsp:compile_for_diagnostics/1` so lint warnings surface alongside compile errors. Each warning carries its rule name (e.g. `function_name_convention`) in the LSP `code` field, so editors can group and filter rules.
- Lint is only invoked on a successful parse, so parse-error paths don't emit spurious lint noise.
- `textDocument/didClose` now removes the document from the in-memory buffer and publishes empty diagnostics to clear editor squiggles.
- CHANGELOG `[Unreleased]` + `docs/cli.md` updated.

Closes #118.

## Test plan
- [x] `rebar3 eunit --module=winn_lsp_tests` — 8/8 pass (3 new: lint warning surfaces with `code`, fixed code clears warning, parse error skips lint)
- [x] `rebar3 eunit` — 640 tests, 1 unrelated pre-existing failure in `winn_generator_tests` (migration dir pollution)
- [ ] Manual smoke: open a `.winn` file in VS Code with the extension pointed at this build, confirm lint squiggles appear and clear on fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)