### PR TITLE
Add `private def` — module-private functions (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Winn language are documented here.
 
+## [Unreleased]
+
+### Language
+- **`private def`** — module-private functions. Functions declared with `private def name(...)` are callable from within the same module but excluded from the module's export list, so cross-module calls raise `undef`. Mirrors the existing `async def` modifier-before-`def` style. Multi-clause and guarded variants both supported. (#128)
+
+### Linter
+- **`unused_private_function`** rule — warns when a `private def` has no call sites in the same module.
+
+### Tooling
+- **`winn docs`** — generated API docs now skip private functions.
+
 ## [0.9.0] - 2026-04-09
 
 ### Breaking Changes

--- a/apps/winn/src/winn_codegen.erl
+++ b/apps/winn/src/winn_codegen.erl
@@ -23,9 +23,14 @@ gen_module({module, _Line, Name, Body}) ->
     Functions = [F || F <- Body, element(1, F) =:= function],
     BehavAttrs = [B || B <- Body, element(1, B) =:= behaviour_attr],
 
-    %% Every def is public in Phase 1/2.
+    %% Functions tagged with `private def` carry a sibling
+    %% {private_marker, _, Name, Arity} form (added by winn_transform).
+    %% Use it to filter the export list.
+    Privates = sets:from_list(
+        [{N, A} || {private_marker, _, N, A} <- Body]),
     Exports = [cerl:c_var({fn_atom(FName), length(Params)})
-               || {function, _, FName, Params, _} <- Functions],
+               || {function, _, FName, Params, _} <- Functions,
+                  not sets:is_element({FName, length(Params)}, Privates)],
 
     Attrs = [{cerl:c_atom(behaviour),
               cerl:abstract([BehName])}

--- a/apps/winn/src/winn_docs.erl
+++ b/apps/winn/src/winn_docs.erl
@@ -103,7 +103,9 @@ collect_module_comments(Lines, N, Acc) ->
     end.
 
 extract_functions(Lines, Body) ->
-    %% Get all function definitions with their line numbers
+    %% Get all function definitions with their line numbers.
+    %% We intentionally only match the public `function` tag, not
+    %% `private_function` — privates are excluded from generated docs.
     RawFns = [{Name, Params, L} || {function, L, Name, Params, _} <- Body],
     %% Group by name (multi-clause functions)
     Grouped = group_functions(RawFns),

--- a/apps/winn/src/winn_lexer.xrl
+++ b/apps/winn/src/winn_lexer.xrl
@@ -39,6 +39,7 @@ Rules.
 module                      : {token, {'module', TokenLine}}.
 agent                       : {token, {'agent', TokenLine}}.
 async                       : {token, {'async', TokenLine}}.
+private                     : {token, {'private', TokenLine}}.
 def                         : {token, {'def', TokenLine}}.
 struct                      : {token, {'struct', TokenLine}}.
 protocol                    : {token, {'protocol', TokenLine}}.

--- a/apps/winn/src/winn_lint.erl
+++ b/apps/winn/src/winn_lint.erl
@@ -51,7 +51,8 @@ lint_form({module, Line, Name, Body}, Acc) ->
     Aliases = collect_aliases(Body),
     Acc2 = lint_module_body(Body, Acc1),
     Acc3 = check_unused_imports(Imports, Body, Acc2),
-    check_unused_aliases(Aliases, Body, Acc3);
+    Acc4 = check_unused_aliases(Aliases, Body, Acc3),
+    check_unused_private_functions(Body, Acc4);
 
 lint_form({agent, Line, Name, Body}, Acc) ->
     Acc1 = check_module_name(Line, Name, Acc),
@@ -59,7 +60,8 @@ lint_form({agent, Line, Name, Body}, Acc) ->
     Aliases = collect_aliases(Body),
     Acc2 = lint_module_body(Body, Acc1),
     Acc3 = check_unused_imports(Imports, Body, Acc2),
-    check_unused_aliases(Aliases, Body, Acc3);
+    Acc4 = check_unused_aliases(Aliases, Body, Acc3),
+    check_unused_private_functions(Body, Acc4);
 
 lint_form(_Other, Acc) ->
     Acc.
@@ -75,6 +77,20 @@ lint_body_form({function, Line, Name, Params, Body}, Acc) ->
     lint_exprs(Body, Acc4);
 
 lint_body_form({function_g, Line, Name, Params, _Guard, Body}, Acc) ->
+    Acc1 = check_function_name(Line, Name, Acc),
+    Acc2 = check_empty_body(Line, Name, Body, Acc1),
+    Acc3 = check_large_function(Line, Name, Body, Acc2),
+    Acc4 = check_unused_variables(Line, Params, Body, Acc3),
+    lint_exprs(Body, Acc4);
+
+lint_body_form({private_function, Line, Name, Params, Body}, Acc) ->
+    Acc1 = check_function_name(Line, Name, Acc),
+    Acc2 = check_empty_body(Line, Name, Body, Acc1),
+    Acc3 = check_large_function(Line, Name, Body, Acc2),
+    Acc4 = check_unused_variables(Line, Params, Body, Acc3),
+    lint_exprs(Body, Acc4);
+
+lint_body_form({private_function_g, Line, Name, Params, _Guard, Body}, Acc) ->
     Acc1 = check_function_name(Line, Name, Acc),
     Acc2 = check_empty_body(Line, Name, Body, Acc1),
     Acc3 = check_large_function(Line, Name, Body, Acc2),
@@ -456,6 +472,73 @@ check_unused_aliases(Aliases, Body, Acc) ->
         end
     end, Acc, Aliases).
 
+%% ── Rule: unused_private_function ──────────────────────────────────────
+
+check_unused_private_functions(Body, Acc) ->
+    Privates = [{Line, Name, length(Params)}
+                || {private_function, Line, Name, Params, _} <- Body]
+            ++ [{Line, Name, length(Params)}
+                || {private_function_g, Line, Name, Params, _, _} <- Body],
+    case Privates of
+        [] -> Acc;
+        _ ->
+            Called = collect_local_call_names(Body),
+            lists:foldl(fun({Line, Name, Arity}, A) ->
+                case sets:is_element(Name, Called) of
+                    true  -> A;
+                    false ->
+                        Msg = io_lib:format(
+                            "Unused private function: '~s/~B'", [Name, Arity]),
+                        [{warning, Line, unused_private_function,
+                          lists:flatten(Msg)} | A]
+                end
+            end, Acc, Privates)
+    end.
+
+%% Collect bare local call names (function-call atoms without a module).
+collect_local_call_names(Forms) ->
+    sets:from_list(local_calls(Forms, [])).
+
+local_calls([], Acc) -> Acc;
+local_calls([F | Rest], Acc) -> local_calls(Rest, local_calls_one(F, Acc));
+local_calls(Other, Acc) -> local_calls_one(Other, Acc).
+
+local_calls_one({call, _, FunName, Args}, Acc) when is_atom(FunName) ->
+    local_calls(Args, [FunName | Acc]);
+local_calls_one({call, _, _, Args}, Acc) ->
+    local_calls(Args, Acc);
+local_calls_one({function, _, _, _, Body}, Acc)         -> local_calls(Body, Acc);
+local_calls_one({function_g, _, _, _, _, Body}, Acc)    -> local_calls(Body, Acc);
+local_calls_one({private_function, _, _, _, Body}, Acc) -> local_calls(Body, Acc);
+local_calls_one({private_function_g, _, _, _, _, Body}, Acc) -> local_calls(Body, Acc);
+local_calls_one({agent_fn, _, _, _, Body}, Acc)         -> local_calls(Body, Acc);
+local_calls_one({agent_fn_g, _, _, _, _, Body}, Acc)    -> local_calls(Body, Acc);
+local_calls_one({agent_cast_fn, _, _, _, Body}, Acc)    -> local_calls(Body, Acc);
+local_calls_one({dot_call, _, _, _, Args}, Acc)         -> local_calls(Args, Acc);
+local_calls_one({op, _, _, L, R}, Acc)                  -> local_calls(R, local_calls_one(L, Acc));
+local_calls_one({unary, _, _, E}, Acc)                  -> local_calls_one(E, Acc);
+local_calls_one({assign, _, _, E}, Acc)                 -> local_calls_one(E, Acc);
+local_calls_one({pipe, _, L, R}, Acc)                   -> local_calls_one(R, local_calls_one(L, Acc));
+local_calls_one({list, _, Es}, Acc)                     -> local_calls(Es, Acc);
+local_calls_one({tuple, _, Es}, Acc)                    -> local_calls(Es, Acc);
+local_calls_one({map, _, Pairs}, Acc) ->
+    lists:foldl(fun({_K, V}, A) -> local_calls_one(V, A) end, Acc, Pairs);
+local_calls_one({if_expr, _, C, T, E}, Acc) ->
+    local_calls(E, local_calls(T, local_calls_one(C, Acc)));
+local_calls_one({switch_expr, _, Scrut, Clauses}, Acc) ->
+    Acc1 = local_calls_one(Scrut, Acc),
+    lists:foldl(fun({case_clause, _, _, _, B}, A) -> local_calls(B, A);
+                   (_, A) -> A
+                end, Acc1, Clauses);
+local_calls_one({case_expr, _, Scrut, Clauses}, Acc) ->
+    Acc1 = local_calls_one(Scrut, Acc),
+    lists:foldl(fun({case_clause, _, _, _, B}, A) -> local_calls(B, A);
+                   (_, A) -> A
+                end, Acc1, Clauses);
+local_calls_one({block_call, _, CallExpr, _, BlockBody}, Acc) ->
+    local_calls(BlockBody, local_calls_one(CallExpr, Acc));
+local_calls_one(_, Acc) -> Acc.
+
 %% Collect all module names referenced in dot_call expressions
 collect_called_modules(Forms) ->
     collect_called_modules(Forms, []).
@@ -477,6 +560,10 @@ collect_calls_from_form({dot_call, _Line, {atom, _, Mod}, _Fun, Args}, Acc) ->
 collect_calls_from_form({function, _Line, _Name, _Params, Body}, Acc) ->
     collect_called_modules(Body, Acc);
 collect_calls_from_form({function_g, _Line, _Name, _Params, _Guard, Body}, Acc) ->
+    collect_called_modules(Body, Acc);
+collect_calls_from_form({private_function, _Line, _Name, _Params, Body}, Acc) ->
+    collect_called_modules(Body, Acc);
+collect_calls_from_form({private_function_g, _Line, _Name, _Params, _Guard, Body}, Acc) ->
     collect_called_modules(Body, Acc);
 collect_calls_from_form({agent_fn, _Line, _Name, _Params, Body}, Acc) ->
     collect_called_modules(Body, Acc);

--- a/apps/winn/src/winn_parser.yrl
+++ b/apps/winn/src/winn_parser.yrl
@@ -38,7 +38,7 @@ Nonterminals
 
 %% Phase 1 terminals + Phase 2 additions.
 Terminals
-    'module' 'agent' 'async' 'def' 'struct' 'protocol' 'impl' 'do' 'end' 'use' 'import' 'alias' 'schema' 'field'
+    'module' 'agent' 'async' 'private' 'def' 'struct' 'protocol' 'impl' 'do' 'end' 'use' 'import' 'alias' 'schema' 'field'
     'match' 'ok_kw' 'err_kw' 'nil_kw'
     'if' 'else' 'switch' 'when' 'try' 'rescue'
     'fn' 'for' 'in'
@@ -160,6 +160,12 @@ function_def -> 'def' ident '(' param_list ')' expr_seq 'end'
 
 function_def -> 'def' ident '(' param_list ')' 'when' expr expr_seq 'end'
     : {function_g, line('$1'), val('$2'), '$4', '$7', '$8'}.
+
+function_def -> 'private' 'def' ident '(' param_list ')' expr_seq 'end'
+    : {private_function, line('$1'), val('$3'), '$5', '$7'}.
+
+function_def -> 'private' 'def' ident '(' param_list ')' 'when' expr expr_seq 'end'
+    : {private_function_g, line('$1'), val('$3'), '$5', '$8', '$9'}.
 
 param_list -> '$empty'       : [].
 param_list -> pattern_list   : '$1'.

--- a/apps/winn/src/winn_transform.erl
+++ b/apps/winn/src/winn_transform.erl
@@ -22,7 +22,11 @@ transform(Forms) when is_list(Forms) ->
 
 %% ── Top-level forms ────────────────────────────────────────────────────────
 
-transform_form({module, Line, Name, Body}) ->
+transform_form({module, Line, Name, Body0}) ->
+    %% Lower `private def` forms to plain `function` forms, capturing
+    %% privacy as a list of `{private_marker, L, Name, Arity}` siblings
+    %% that the codegen reads to filter exports.
+    {Body, PrivateMarkers} = lower_private_fns(Body0),
     %% Separate use, import, alias directives, schema defs, and regular functions.
     {UseDirs, Rest1}    = lists:partition(fun({use_directive,_,_,_}) -> true; (_) -> false end, Body),
     {ImportDirs, Rest2} = lists:partition(fun({import_directive,_,_}) -> true; (_) -> false end, Rest1),
@@ -68,7 +72,7 @@ transform_form({module, Line, Name, Body}) ->
             [rewrite_directives(F, Imports, AliasMap, LocalFns) || F <- Merged]
     end,
 
-    {module, Line, Name, BehaviourAttrs ++ SyntheticFns ++ Final};
+    {module, Line, Name, BehaviourAttrs ++ SyntheticFns ++ Final ++ PrivateMarkers};
 %% ── Agent desugaring ─────────────────────────────────────────────────────
 %% An `agent` block is desugared into a module with GenServer infrastructure.
 %% The result is fed back into transform_form({module,...}) for normal processing.
@@ -574,6 +578,24 @@ expand_schema_def({schema_def, L, TableBin, Fields}, ModName) ->
 
     [SourceFn, FieldsFn, TypesFn, NewFn,
      AllFn, FindFn, FindByFn, CreateFn, DeleteFn, CountFn].
+
+%% ── Private function lowering ──────────────────────────────────────────────
+%% Rewrite each {private_function, ...} (and the guarded variant) to a plain
+%% {function, ...} so the rest of the pipeline doesn't need to know about
+%% privacy. Privacy is recorded out-of-band as {private_marker, L, Name, Arity}
+%% siblings, which winn_codegen reads to filter the export list.
+
+lower_private_fns(Body) ->
+    lists:foldr(fun lower_private_one/2, {[], []}, Body).
+
+lower_private_one({private_function, L, Name, Params, FBody}, {Forms, Markers}) ->
+    Marker = {private_marker, L, Name, length(Params)},
+    {[{function, L, Name, Params, FBody} | Forms], [Marker | Markers]};
+lower_private_one({private_function_g, L, Name, Params, Guard, FBody}, {Forms, Markers}) ->
+    Marker = {private_marker, L, Name, length(Params)},
+    {[{function_g, L, Name, Params, Guard, FBody} | Forms], [Marker | Markers]};
+lower_private_one(Other, {Forms, Markers}) ->
+    {[Other | Forms], Markers}.
 
 %% ── Function transformation ────────────────────────────────────────────────
 

--- a/apps/winn/test/winn_private_fns_tests.erl
+++ b/apps/winn/test/winn_private_fns_tests.erl
@@ -1,0 +1,122 @@
+%% winn_private_fns_tests.erl
+%% Tests for `private def` — module-private functions (#128).
+
+-module(winn_private_fns_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_and_load(Source) ->
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% ── Parser ───────────────────────────────────────────────────────────────
+
+private_def_parses_test() ->
+    Source = "module Pp\n  private def helper(x)\n    x\n  end\nend\n",
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, [{module, _, _, [{private_function, _, helper, _, _}]}]} =
+        winn_parser:parse(Tokens),
+    ok.
+
+private_def_with_guard_parses_test() ->
+    Source = "module Pp\n  private def positive(x) when x > 0\n    x\n  end\nend\n",
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, [{module, _, _, [{private_function_g, _, positive, _, _, _}]}]} =
+        winn_parser:parse(Tokens),
+    ok.
+
+%% ── Codegen / runtime ────────────────────────────────────────────────────
+
+private_function_excluded_from_exports_test() ->
+    Mod = compile_and_load(
+        "module ExportFilter\n"
+        "  def public_one()\n"
+        "    1\n"
+        "  end\n"
+        "  private def helper(x)\n"
+        "    x + 1\n"
+        "  end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    ?assert(lists:member({public_one, 0}, Exports)),
+    ?assertNot(lists:member({helper, 1}, Exports)).
+
+private_function_callable_from_same_module_test() ->
+    Mod = compile_and_load(
+        "module SameMod\n"
+        "  def double_it(x)\n"
+        "    helper(x)\n"
+        "  end\n"
+        "  private def helper(x)\n"
+        "    x * 2\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(10, Mod:double_it(5)).
+
+private_function_external_call_undef_test() ->
+    Mod = compile_and_load(
+        "module ExtCall\n"
+        "  def public_fn()\n"
+        "    1\n"
+        "  end\n"
+        "  private def secret()\n"
+        "    42\n"
+        "  end\n"
+        "end\n"),
+    ?assertError(undef, Mod:secret()).
+
+guarded_private_function_works_test() ->
+    Mod = compile_and_load(
+        "module GuardPriv\n"
+        "  def call_it(n)\n"
+        "    positive(n)\n"
+        "  end\n"
+        "  private def positive(x) when x > 0\n"
+        "    x\n"
+        "  end\n"
+        "  private def positive(_x)\n"
+        "    0\n"
+        "  end\n"
+        "end\n"),
+    ?assertEqual(7, Mod:call_it(7)),
+    ?assertEqual(0, Mod:call_it(-3)),
+    Exports = Mod:module_info(exports),
+    ?assertNot(lists:member({positive, 1}, Exports)).
+
+%% ── Lint ─────────────────────────────────────────────────────────────────
+
+unused_private_function_warning_test() ->
+    Source =
+        "module UnusedPriv\n"
+        "  def main()\n"
+        "    1\n"
+        "  end\n"
+        "  private def dead_code()\n"
+        "    99\n"
+        "  end\n"
+        "end\n",
+    {ok, Warnings} = winn_lint:check_string(Source),
+    Matching = [W || {warning, _, unused_private_function, _} = W <- Warnings],
+    ?assertEqual(1, length(Matching)).
+
+used_private_function_no_warning_test() ->
+    Source =
+        "module UsedPriv\n"
+        "  def main()\n"
+        "    helper(1)\n"
+        "  end\n"
+        "  private def helper(x)\n"
+        "    x + 1\n"
+        "  end\n"
+        "end\n",
+    {ok, Warnings} = winn_lint:check_string(Source),
+    Matching = [W || {warning, _, unused_private_function, _} = W <- Warnings],
+    ?assertEqual([], Matching).

--- a/docs/language.md
+++ b/docs/language.md
@@ -102,6 +102,39 @@ module Math
 end
 ```
 
+### Private Functions
+
+Functions declared with `private def` are callable from within the same module but not exported, so other modules cannot call them. The `private` modifier mirrors the `async def` style used in agents.
+
+```winn
+module Greeter
+  def greet(name)
+    "#{prefix()}, #{name}!"
+  end
+
+  private def prefix()
+    "Hello"
+  end
+end
+
+Greeter.greet("Alice")    # => "Hello, Alice!"
+Greeter.prefix()          # => undef error — prefix is private
+```
+
+Multi-clause and guarded private functions are both supported:
+
+```winn
+private def positive(x) when x > 0
+  x
+end
+
+private def positive(_x)
+  0
+end
+```
+
+Generated API docs (`winn docs`) skip private functions, and the linter warns when a private function has no call sites in its module (`unused_private_function`).
+
 ### Default Parameter Values
 
 Parameters can have default values. When called with fewer arguments, defaults are filled in:


### PR DESCRIPTION
## Summary
Closes #128. Adds `private def` syntax for module-private functions, mirroring the existing `async def` modifier style:

```winn
module Greeter
  def greet(name)
    "#{prefix()}, #{name}!"
  end

  private def prefix()
    "Hello"
  end
end
```

- `Greeter.greet("Alice")` works.
- `Greeter.prefix()` raises `undef` — `prefix/0` is not in the module's export list.
- Multi-clause and guarded private functions are both supported.
- Generated API docs (`winn docs`) skip privates.
- New lint rule `unused_private_function` warns on dead-code privates.

## Implementation note
A new `{private_function, ...}` AST tag is introduced at the parser level. `winn_transform` lowers it early to a plain `{function, ...}` form plus a sibling `{private_marker, L, Name, Arity}` attribute. `winn_codegen` reads those markers to filter the export list.

This out-of-band privacy approach avoids rewriting the **119 sites** that match `{function, ...}` across the codebase — privacy threads through the pipeline without touching downstream passes.

## Test plan
- [x] `rebar3 eunit --module=winn_private_fns_tests` — 8/8 pass
  - parser tags (private_function, private_function_g)
  - export filtering (private not in `module_info(exports)`)
  - same-module call works
  - cross-module call raises `undef`
  - guarded multi-clause private dispatches correctly
  - lint warns on unused private; no warning when private is called
- [x] `rebar3 eunit` — 645 tests, 0 failures
- [ ] Manual: scaffold a project, add a `private def`, run `winn docs`, confirm it's omitted
- [ ] VS Code grammar update (`language-winn-vscode`) — follow-up PR to highlight `private`

🤖 Generated with [Claude Code](https://claude.com/claude-code)