### PR TITLE
Fix Repo.configure binary host crashing epgsql connect (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Winn language are documented here.
 
+## [0.9.1] - Unreleased
+
+### Fixes
+- **`Repo.configure` with binary host now works** ([#145](https://github.com/gregwinn/winn-lang/issues/145)) — when Winn code called `Repo.configure(%{host: ...})` the map values were stored as binaries in ETS, and `winn_repo:connect/0` passed them directly to `epgsql:connect/1` → `gen_tcp:connect/4`, which rejects binary hosts with `badarg`. This broke any project reading `DB_HOST` from an env var (the scaffolder default pattern). Fixed by normalizing `host`, `database`, `username`, and `password` to charlists before handing the config to epgsql. The same normalization is applied in `winn_pool:create_one/1` for pooled connections.
+
 ## [0.9.0] - 2026-04-09
 
 ### Breaking Changes

--- a/apps/winn/src/winn_pool.erl
+++ b/apps/winn/src/winn_pool.erl
@@ -116,10 +116,7 @@ create_connections(Config, N) ->
     {Conns, Errors}.
 
 create_one(Config) ->
-    #{host := Host, port := Port, database := DB,
-      username := User, password := Pass} = Config,
-    epgsql:connect(#{host => Host, port => Port, database => DB,
-                     username => User, password => Pass}).
+    epgsql:connect(winn_repo:normalize_epgsql_config(Config)).
 
 is_alive(Conn) when is_pid(Conn) ->
     erlang:is_process_alive(Conn);

--- a/apps/winn/src/winn_repo.erl
+++ b/apps/winn/src/winn_repo.erl
@@ -7,7 +7,7 @@
     'query.new'/1, 'query.where'/3, 'query.limit'/2,
     'query.order_by'/3, 'query.select'/2, 'query.count'/1,
     sql_for_insert/2, sql_for_select/2,
-    build_where/1
+    build_where/1, normalize_epgsql_config/1
 ]).
 
 %% Configure the database connection from Winn:
@@ -69,11 +69,29 @@ connect() ->
         sqlite ->
             winn_repo_sqlite:connect(Config);
         _ ->
-            #{host := Host, port := Port, database := DB,
-              username := User, password := Pass} = Config,
-            epgsql:connect(#{host => Host, port => Port, database => DB,
-                             username => User, password => Pass})
+            epgsql:connect(normalize_epgsql_config(Config))
     end.
+
+%% Normalize a db config map into the shape epgsql expects.
+%% Winn code calls `Repo.configure(%{host: "...", ...})` which stores
+%% the values as binaries in ETS. epgsql forwards `host` to
+%% `gen_tcp:connect/4` which rejects binaries, so we must convert
+%% string-like fields to charlists before calling epgsql:connect/1.
+%%
+%% Normalizes in place so callers can pass additional epgsql options
+%% (ssl, ssl_opts, timeout, connect_timeout, ...) without losing them.
+normalize_epgsql_config(Config) when is_map(Config) ->
+    StringKeys = [host, database, username, password],
+    lists:foldl(fun(Key, Acc) ->
+        case maps:find(Key, Acc) of
+            {ok, V} -> Acc#{Key => to_charlist(V)};
+            error   -> Acc
+        end
+    end, Config, StringKeys).
+
+to_charlist(V) when is_binary(V) -> binary_to_list(V);
+to_charlist(V) when is_list(V)   -> V;
+to_charlist(V) when is_atom(V)   -> atom_to_list(V).
 
 adapter() ->
     maps:get(adapter, db_config(), postgres).

--- a/apps/winn/test/winn_repo_config_tests.erl
+++ b/apps/winn/test/winn_repo_config_tests.erl
@@ -67,3 +67,72 @@ configure_from_winn_test() ->
     ok = ModName:run(),
     ?assertEqual(<<"myhost">>, winn_config:get(repo, host)),
     ?assertEqual(<<"mydb">>, winn_config:get(repo, database)).
+
+%% ── Binary → charlist normalization for epgsql (#145) ──────────────────────
+
+normalize_epgsql_config_converts_binaries_to_charlists_test() ->
+    Config = #{
+        host     => <<"postgresql.databases.svc.cluster.local">>,
+        port     => 5432,
+        database => <<"myapp">>,
+        username => <<"postgres">>,
+        password => <<"secret">>
+    },
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual("postgresql.databases.svc.cluster.local", maps:get(host, Normalized)),
+    ?assertEqual(5432, maps:get(port, Normalized)),
+    ?assertEqual("myapp", maps:get(database, Normalized)),
+    ?assertEqual("postgres", maps:get(username, Normalized)),
+    ?assertEqual("secret", maps:get(password, Normalized)).
+
+normalize_epgsql_config_passes_through_charlists_test() ->
+    Config = #{
+        host     => "localhost",
+        port     => 5432,
+        database => "winn_dev",
+        username => "postgres",
+        password => ""
+    },
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual("localhost", maps:get(host, Normalized)),
+    ?assertEqual("winn_dev", maps:get(database, Normalized)),
+    ?assertEqual("postgres", maps:get(username, Normalized)),
+    ?assertEqual("", maps:get(password, Normalized)).
+
+normalize_epgsql_config_handles_atom_host_test() ->
+    Config = #{
+        host     => localhost,
+        port     => 5432,
+        database => <<"mydb">>,
+        username => <<"u">>,
+        password => <<"p">>
+    },
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual("localhost", maps:get(host, Normalized)).
+
+normalize_epgsql_config_preserves_extra_keys_test() ->
+    %% epgsql supports ssl, ssl_opts, timeout, connect_timeout, etc.
+    %% The normalizer must not drop them.
+    Config = #{
+        host          => <<"db.example.com">>,
+        port          => 5432,
+        database      => <<"mydb">>,
+        username      => <<"u">>,
+        password      => <<"p">>,
+        ssl           => required,
+        ssl_opts      => [{verify, verify_peer}],
+        timeout       => 10000
+    },
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual(required, maps:get(ssl, Normalized)),
+    ?assertEqual([{verify, verify_peer}], maps:get(ssl_opts, Normalized)),
+    ?assertEqual(10000, maps:get(timeout, Normalized)),
+    ?assertEqual("db.example.com", maps:get(host, Normalized)).
+
+normalize_epgsql_config_tolerates_missing_keys_test() ->
+    %% Exported function: callers may pass partial maps. Should not crash.
+    Config = #{host => <<"db.example.com">>, port => 5432},
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual("db.example.com", maps:get(host, Normalized)),
+    ?assertEqual(5432, maps:get(port, Normalized)),
+    ?assertEqual(error, maps:find(database, Normalized)).


### PR DESCRIPTION
Closes #145.

## Problem

Winn code calling `Repo.configure(%{host: System.get_env("DB_HOST", "localhost")})` stores the map values in ETS as Erlang binaries. `winn_repo:connect/0` then passed them directly to `epgsql:connect/1`, which forwards `host` to `gen_tcp:connect/4` — and `gen_tcp:connect/4` rejects binary hosts with `badarg`. Every DB call crashed when `DB_HOST` was set to a real hostname via env var, which is the exact pattern the scaffolder generates in `config/config.winn`.

## Fix

Added `winn_repo:normalize_epgsql_config/1` which converts `host`, `database`, `username`, and `password` to charlists in place, preserving any additional epgsql options the caller may have passed (`ssl`, `ssl_opts`, `timeout`, `connect_timeout`, etc).

- `winn_repo:connect/0` now routes the postgres branch through the helper
- `winn_pool:create_one/1` calls the same helper for pooled connections
- Works for binary, charlist, and atom inputs (e.g. `localhost` atom → `"localhost"`)

## Tests

Added five new tests in `winn_repo_config_tests.erl`:

- `normalize_epgsql_config_converts_binaries_to_charlists_test` — the repro case from #145
- `normalize_epgsql_config_passes_through_charlists_test` — backward compat for users already passing charlists
- `normalize_epgsql_config_handles_atom_host_test` — atom hosts like `localhost` convert to strings
- `normalize_epgsql_config_preserves_extra_keys_test` — `ssl`, `ssl_opts`, `timeout` are not dropped
- `normalize_epgsql_config_tolerates_missing_keys_test` — partial maps don't crash

## CHANGELOG

Added a `[0.9.1] - Unreleased` section with the fix note.

## Test plan
- [ ] CI passes on both OTP 27 and OTP 28
- [ ] New tests pass (`rebar3 eunit --module=winn_repo_config_tests`)
- [ ] Manual: scaffold a project with `DB_HOST=postgres.example.com` in `.env`, confirm `Repo.execute` no longer crashes with `badarg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)