### PR TITLE
Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Winn language are documented here.
 
-## [0.9.1] - Unreleased
+## [0.9.1] - 2026-04-12
 
 ### Fixes
 - **`Repo.configure` with binary host now works** ([#145](https://github.com/gregwinn/winn-lang/issues/145)) — when Winn code called `Repo.configure(%{host: ...})` the map values were stored as binaries in ETS, and `winn_repo:connect/0` passed them directly to `epgsql:connect/1` → `gen_tcp:connect/4`, which rejects binary hosts with `badarg`. This broke any project reading `DB_HOST` from an env var (the scaffolder default pattern). Fixed by normalizing `host`, `database`, `username`, and `password` to charlists before handing the config to epgsql. The same normalization is applied in `winn_pool:create_one/1` for pooled connections.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 rebar3 compile              # Compile everything
-rebar3 eunit                # Run all 537 tests
+rebar3 eunit                # Run all 642 tests
 rebar3 eunit --module=winn_l1_tests  # Run a single test module
 rebar3 escriptize           # Build the winn CLI escript
 ./_build/default/bin/winn help       # Verify CLI works

--- a/apps/winn/src/winn.app.src
+++ b/apps/winn/src/winn.app.src
@@ -1,6 +1,6 @@
 {application, winn, [
     {description, "The Winn programming language compiler"},
-    {vsn, "0.9.0"},
+    {vsn, "0.9.1"},
     {registered, []},
     {applications, [kernel, stdlib, compiler, cowboy, jsone]},
     {env, []},

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -1076,7 +1076,7 @@ is_tty() ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.0"
+        _         -> "0.9.1"
     end.
 
 print_version() ->

--- a/apps/winn/src/winn_lsp.erl
+++ b/apps/winn/src/winn_lsp.erl
@@ -47,7 +47,7 @@ handle_message(#{<<"method">> := <<"initialize">>, <<"id">> := Id} = _Msg, State
         },
         <<"serverInfo">> => #{
             <<"name">> => <<"winn-lsp">>,
-            <<"version">> => <<"0.9.0">>
+            <<"version">> => <<"0.9.1">>
         }
     },
     send_response(Id, Result),

--- a/apps/winn/src/winn_repl.erl
+++ b/apps/winn/src/winn_repl.erl
@@ -230,5 +230,5 @@ get_binding(Name) when is_list(Name) ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.0"
+        _         -> "0.9.1"
     end.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ Requires Erlang/OTP 25+ and rebar3.
 
 ```sh
 winn version
-# => winn 0.9.0
+# => winn 0.9.1
 
 winn help
 ```
@@ -73,7 +73,7 @@ winn help
 You should see:
 
 ```
-Winn 0.9.0 - a compiled language on the BEAM
+Winn 0.9.1 - a compiled language on the BEAM
 
 Usage:
   winn new <name>         Create a new Winn project

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Winn Roadmap
 
-## Current Status — v0.9.0
+## Current Status — v0.9.1
 
-635 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics. LSP with inline errors and autocomplete.
+642 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics. LSP with inline errors and autocomplete.
 
 ### What's Shipped
 
@@ -17,6 +17,7 @@
 | v0.7.0 | Core Stdlib + Packages | File I/O, Regex, Timer, Retry, DateTime/String, package system (`winn add`/`winn remove`), [winn-redis](https://github.com/gregwinn/winn-redis), [winn-mongodb](https://github.com/gregwinn/winn-mongodb), [winn-amqp](https://github.com/gregwinn/winn-amqp) |
 | v0.8.0 | Web Framework + Agents | Static files, CORS, auth middleware, health checks, `agent` keyword with `@state` syntax and `async def`, compiles to GenServer |
 | v0.9.0 | Developer Tooling | `winn fmt`, `winn lint` (10 rules), `winn lsp` (diagnostics + autocomplete), improved `winn new` (--api, --minimal), command shortcuts, codegen split |
+| v0.9.1 | Bug fix | `Repo.configure` binary host crashing epgsql connect ([#145](https://github.com/gregwinn/winn-lang/issues/145)) |
 
 ---
 


### PR DESCRIPTION
Version bump and release prep for v0.9.1 — a patch release containing the fix for #145.

## Changes

- Bump version to 0.9.1 in:
  - `apps/winn/src/winn.app.src`
  - `apps/winn/src/winn_cli.erl` (fallback string)
  - `apps/winn/src/winn_repl.erl` (fallback string)
  - `apps/winn/src/winn_lsp.erl` (serverInfo)
- Date the CHANGELOG entry (`[0.9.1] - 2026-04-12`)
- `docs/getting-started.md` — version in `winn version` and help snippets
- `docs/roadmap.md` — current status, shipped table, test count
- `CLAUDE.md` — test count (537 → 642)

## Included fixes

- #145 — `Repo.configure` binary host crashing epgsql connect (landed in PR #146)

## Release checklist

- [x] Versions bumped
- [x] CHANGELOG dated
- [x] Docs updated (getting-started, roadmap, CLAUDE.md)
- [ ] Merge this PR
- [ ] Tag v0.9.1 on main
- [ ] `gh release create v0.9.1`
- [ ] Update `gregwinn/homebrew-winn` formula with new URL + SHA256
- [ ] Update website (version in footer + sync docs)
- [ ] Close v0.9.1 milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)