### PR TITLE
Add release automation (tag-to-release + homebrew-update)

### DIFF
--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -1,0 +1,103 @@
+name: Update Homebrew Formula
+
+# When a GitHub release is published, update gregwinn/homebrew-winn
+# Formula/winn.rb to point to the new tag and source tarball sha256.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-homebrew:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute source tarball sha256
+        id: sha
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          URL="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${TAG}.tar.gz"
+          echo "Downloading $URL"
+
+          # GitHub generates source tarballs lazily — retry with backoff
+          # to avoid racing the release publish event. We must verify the
+          # downloaded file is actually a gzip tarball (not an HTML error
+          # page) before computing the hash, otherwise we could commit
+          # sha256("<html>404</html>") into the formula.
+          SHA=""
+          for attempt in 1 2 3 4 5 6; do
+            TMP=$(mktemp)
+            if curl -fsSL --retry 3 --retry-delay 2 "$URL" -o "$TMP"; then
+              # Gzip magic bytes: 1f 8b
+              MAGIC=$(head -c 2 "$TMP" | xxd -p)
+              if [ "$MAGIC" = "1f8b" ]; then
+                CANDIDATE=$(sha256sum "$TMP" | cut -d' ' -f1)
+                if [[ "$CANDIDATE" =~ ^[a-f0-9]{64}$ ]]; then
+                  SHA="$CANDIDATE"
+                  rm -f "$TMP"
+                  break
+                fi
+              else
+                echo "Attempt $attempt: got non-gzip response (magic=$MAGIC), tarball likely not ready"
+              fi
+            fi
+            rm -f "$TMP"
+            echo "Sleeping 10s before retry..."
+            sleep 10
+          done
+
+          if [ -z "$SHA" ]; then
+            echo "Failed to compute sha256 for $URL after 6 attempts" >&2
+            exit 1
+          fi
+
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Computed sha256: $SHA"
+
+      - name: Checkout homebrew-winn
+        uses: actions/checkout@v4
+        with:
+          repository: gregwinn/homebrew-winn
+          token: ${{ secrets.REPO_TOKEN }}
+          path: homebrew-winn
+
+      - name: Update formula
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          SHA: ${{ steps.sha.outputs.sha256 }}
+        run: |
+          cd homebrew-winn
+          FORMULA=Formula/winn.rb
+
+          # Replace the url line (any previous tag)
+          sed -i -E "s|archive/refs/tags/v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz|archive/refs/tags/${TAG}.tar.gz|" "$FORMULA"
+
+          # Replace the sha256 line (keep indentation)
+          sed -i -E "s|^(\s*sha256 )\"[a-f0-9]{64}\"|\1\"${SHA}\"|" "$FORMULA"
+
+          echo "--- updated formula ---"
+          cat "$FORMULA"
+          echo "--- end formula ---"
+
+      - name: Commit and push formula update
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          cd homebrew-winn
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/winn.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date for $TAG — nothing to commit"
+          else
+            git commit -m "Update formula to ${TAG}"
+            git push
+          fi

--- a/.github/workflows/tag-to-release.yml
+++ b/.github/workflows/tag-to-release.yml
@@ -1,0 +1,104 @@
+name: Tag to Release
+
+# When a version tag (vX.Y.Z) is pushed, create a GitHub release with the
+# matching CHANGELOG.md section as the body, then close the matching
+# GitHub milestone. Publishing the release triggers release.yml and
+# homebrew-update.yml.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract CHANGELOG section
+        id: changelog
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Pull the section between ## [VERSION] and the next ## [
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\["ver"\\]" {flag=1; next}
+            flag && /^## \[/ {exit}
+            flag {print}
+          ' CHANGELOG.md > /tmp/notes.md
+
+          # Strip leading blank lines
+          sed -i '/./,$!d' /tmp/notes.md
+
+          if [ ! -s /tmp/notes.md ]; then
+            echo "No CHANGELOG section found for $VERSION — will fall back to auto-generated notes"
+            echo "has_notes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_notes=true" >> "$GITHUB_OUTPUT"
+            echo "--- notes preview ---"
+            cat /tmp/notes.md
+            echo "--- end preview ---"
+          fi
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release $GITHUB_REF_NAME already exists — skipping creation"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release (with CHANGELOG notes)
+        if: steps.check.outputs.exists == 'false' && steps.changelog.outputs.has_notes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/notes.md
+
+      - name: Create GitHub release (auto-generated notes fallback)
+        if: steps.check.outputs.exists == 'false' && steps.changelog.outputs.has_notes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes
+
+      - name: Close matching milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find a milestone whose title matches the tag (vX.Y.Z).
+          # Pass the tag to jq via --arg so tag content can't break
+          # the jq filter syntax.
+          MILESTONE_NUMBER=$(gh api \
+            "repos/$GITHUB_REPOSITORY/milestones?state=open" \
+            | jq -r --arg t "$GITHUB_REF_NAME" \
+                '.[] | select(.title == $t) | .number' | head -1)
+
+          if [ -z "$MILESTONE_NUMBER" ]; then
+            echo "No open milestone matching $GITHUB_REF_NAME — skipping"
+          else
+            echo "Closing milestone #$MILESTONE_NUMBER ($GITHUB_REF_NAME)"
+            gh api "repos/$GITHUB_REPOSITORY/milestones/$MILESTONE_NUMBER" \
+              -X PATCH -f state=closed --jq '.state'
+          fi


### PR DESCRIPTION
Automates the release process so cutting vX.Y.Z becomes: bump versions → tag → push tag. Everything else happens automatically.

## New workflows

### `tag-to-release.yml` — on `push: tags: [v*]`
- Extracts the matching CHANGELOG.md section via awk
- Creates the GitHub release with those notes (or `--generate-notes` fallback)
- Closes the matching GitHub milestone if one exists
- Idempotent: checks whether the release already exists before creating

### `homebrew-update.yml` — on `release: [published]`
- Computes the source tarball sha256 with retry + gzip magic-byte verification (avoids committing the hash of an error page if GitHub's tarball endpoint lags behind release creation)
- Sed-replaces the url and sha256 lines in `Formula/winn.rb` on `gregwinn/homebrew-winn`
- Commits and pushes; idempotent if already up to date

## Coexistence with existing `release.yml`

The existing `release.yml` (binary upload, .deb/.rpm packaging, apt repo update) continues to fire on `release: [published]`, unchanged. `homebrew-update.yml` runs in parallel to it.

## Hardening from code review
- Retry loop with gzip magic-byte check on the tarball fetch (prevents corrupt sha256 from a 404 HTML response)
- `jq --arg` for the milestone lookup (no shell injection via tag name)
- `sha256` output validated as exactly 64 hex chars before use
- Formula update is idempotent (`git diff --cached --quiet` guard)

## Secrets required
- `REPO_TOKEN` (already exists; used by existing apt repo job) — needs write access to `gregwinn/homebrew-winn`

## Test plan
- [ ] Merge this to develop
- [ ] Merge develop → main as part of the next release
- [ ] Cut v0.9.2 (or whichever comes next) to validate the end-to-end flow: tag push should auto-create release, fire existing release.yml, and update Homebrew formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)