### PR TITLE
Fix nfpm asset URL — unblocks .deb/.rpm build for v0.9.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,11 @@ jobs:
 
       - name: Install nfpm
         run: |
-          curl -sfL https://github.com/goreleaser/nfpm/releases/download/v2.41.1/nfpm_2.41.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin nfpm
+          # Asset is nfpm_<version>_Linux_x86_64.tar.gz (capital L, x86_64)
+          curl -sfL --retry 3 --retry-delay 5 \
+            https://github.com/goreleaser/nfpm/releases/download/v2.41.1/nfpm_2.41.1_Linux_x86_64.tar.gz \
+            | sudo tar xz -C /usr/local/bin nfpm
+          nfpm --version
 
       - name: Extract version
         id: version


### PR DESCRIPTION
The v0.9.1 release completed the binary upload but `build-linux-packages` failed and `update-apt-repo` was skipped. Cause: the nfpm asset URL uses `linux_amd64` but the actual asset is named `Linux_x86_64`.

```
curl: https://github.com/goreleaser/nfpm/releases/download/v2.41.1/nfpm_2.41.1_linux_amd64.tar.gz
→ 404
→ tar: unexpected end of file
```

Actual asset name from the nfpm v2.41.1 release: `nfpm_2.41.1_Linux_x86_64.tar.gz`.

## Fix

- Correct the asset URL
- Add `curl --retry 3 --retry-delay 5` for network robustness
- Add `sudo` on the tar extraction (some hosted runners don't allow the runner user to write to `/usr/local/bin`)
- Print `nfpm --version` after install to verify

## After merge

Re-run the v0.9.1 release workflow to pick up the fix and get the .deb/.rpm packages + apt repo update. Can be done via:

```
gh run rerun 24321710204
```

or by deleting + recreating the v0.9.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)