### PR TITLE
Release v0.9.2 — winn_pool trap_exit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Winn language are documented here.
 
+## [0.9.2] - 2026-04-12
+
+### Fixes
+- **`winn_pool` race: trap exits from failed epgsql connects** — `winn_pool:init/1` called `epgsql:connect/1` during startup to build the initial pool. On failure (e.g. `econnrefused` in CI with no database), `epgsql`'s internal `gen_server` terminated with the connect error reason and propagated via the link to `winn_pool`. Without `trap_exit`, the pool inherited that exit and died. The flakiness was masked before v0.9.1 because the earlier binary-host bug crashed `gen_tcp:connect/4` with `badarg` before reaching the link-exit path; fixing #145 unmasked the race. Set `process_flag(trap_exit, true)` in `winn_pool:init/1` so EXIT signals from failed connects become ignorable messages.
+- **Release infrastructure: nfpm asset URL** — the `build-linux-packages` job in `.github/workflows/release.yml` used the wrong nfpm asset name (`linux_amd64` vs the actual `Linux_x86_64`), which 404'd and caused the v0.9.1 `.deb`/`.rpm` builds to fail. Fixed the URL and added curl retry.
+
 ## [0.9.1] - 2026-04-12
 
 ### Fixes

--- a/apps/winn/src/winn.app.src
+++ b/apps/winn/src/winn.app.src
@@ -1,6 +1,6 @@
 {application, winn, [
     {description, "The Winn programming language compiler"},
-    {vsn, "0.9.1"},
+    {vsn, "0.9.2"},
     {registered, []},
     {applications, [kernel, stdlib, compiler, cowboy, jsone]},
     {env, []},

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -1076,7 +1076,7 @@ is_tty() ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.1"
+        _         -> "0.9.2"
     end.
 
 print_version() ->

--- a/apps/winn/src/winn_lsp.erl
+++ b/apps/winn/src/winn_lsp.erl
@@ -47,7 +47,7 @@ handle_message(#{<<"method">> := <<"initialize">>, <<"id">> := Id} = _Msg, State
         },
         <<"serverInfo">> => #{
             <<"name">> => <<"winn-lsp">>,
-            <<"version">> => <<"0.9.1">>
+            <<"version">> => <<"0.9.2">>
         }
     },
     send_response(Id, Result),

--- a/apps/winn/src/winn_pool.erl
+++ b/apps/winn/src/winn_pool.erl
@@ -37,6 +37,14 @@ status() ->
 %% ── GenServer callbacks ──────────────────────────────────────────────────────
 
 init(Config) ->
+    %% Trap exits so that links from failed epgsql:connect/1 attempts
+    %% (epgsql's internal gen_server terminates with the connect error
+    %% and propagates via the link) arrive as {'EXIT', Pid, Reason}
+    %% messages instead of killing the pool. Without this, a failed
+    %% initial connection attempt in create_connections/2 would take
+    %% down the whole pool with the connection's exit reason (e.g.
+    %% econnrefused) — flaky because of timing.
+    process_flag(trap_exit, true),
     PoolSize = maps:get(pool_size, Config, ?DEFAULT_POOL_SIZE),
     ConnConfig = maps:without([pool_size], Config),
     %% Create initial connections

--- a/apps/winn/src/winn_repl.erl
+++ b/apps/winn/src/winn_repl.erl
@@ -230,5 +230,5 @@ get_binding(Name) when is_list(Name) ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.1"
+        _         -> "0.9.2"
     end.

--- a/apps/winn/test/winn_pool_tests.erl
+++ b/apps/winn/test/winn_pool_tests.erl
@@ -19,12 +19,27 @@ configure_pool_size_test() ->
 %% ── pool_status when pool not started ───────────────────────────────────────
 
 pool_not_started_test() ->
-    %% Ensure pool is not running
+    %% Ensure pool is not running. gen_server:stop may return with a
+    %% non-normal reason when the pool's linked connection attempts
+    %% failed (econnrefused in CI with no DB) — swallow those since we
+    %% only care that the process is gone afterwards.
     case whereis(winn_pool) of
         undefined -> ok;
-        Pid -> gen_server:stop(Pid)
+        Pid ->
+            try gen_server:stop(Pid, normal, 1000)
+            catch exit:_ -> ok
+            end,
+            %% Wait for the name to actually be released
+            wait_for_unregister(winn_pool, 20)
     end,
     ?assertEqual({error, pool_not_started}, winn_repo:pool_status()).
+
+wait_for_unregister(_Name, 0) -> timeout;
+wait_for_unregister(Name, N) ->
+    case whereis(Name) of
+        undefined -> ok;
+        _ -> timer:sleep(50), wait_for_unregister(Name, N - 1)
+    end.
 
 %% ── Repo exports pool functions ─────────────────────────────────────────────
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ Requires Erlang/OTP 25+ and rebar3.
 
 ```sh
 winn version
-# => winn 0.9.1
+# => winn 0.9.2
 
 winn help
 ```
@@ -73,7 +73,7 @@ winn help
 You should see:
 
 ```
-Winn 0.9.1 - a compiled language on the BEAM
+Winn 0.9.2 - a compiled language on the BEAM
 
 Usage:
   winn new <name>         Create a new Winn project

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Winn Roadmap
 
-## Current Status — v0.9.1
+## Current Status — v0.9.2
 
 642 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics. LSP with inline errors and autocomplete.
 
@@ -18,6 +18,7 @@
 | v0.8.0 | Web Framework + Agents | Static files, CORS, auth middleware, health checks, `agent` keyword with `@state` syntax and `async def`, compiles to GenServer |
 | v0.9.0 | Developer Tooling | `winn fmt`, `winn lint` (10 rules), `winn lsp` (diagnostics + autocomplete), improved `winn new` (--api, --minimal), command shortcuts, codegen split |
 | v0.9.1 | Bug fix | `Repo.configure` binary host crashing epgsql connect ([#145](https://github.com/gregwinn/winn-lang/issues/145)) |
+| v0.9.2 | Bug fix | `winn_pool` race: trap exits from failed epgsql connects + release infra nfpm URL fix |
 
 ---
 


### PR DESCRIPTION
Patch release v0.9.2 bundling a runtime fix and the release-infra fix that landed in #149.

## Runtime fix — `winn_pool` race

`winn_pool:init/1` calls `epgsql:connect/1` during startup to build the initial pool. On failure (e.g. `econnrefused` in CI with no database), `epgsql:connect/1` returns `{error, econnrefused}` cleanly, **but** its internal `epgsql_sock` gen_server terminates with the connect error reason and the termination propagates via the link to `winn_pool`. Without `trap_exit`, the pool inherits that exit and dies with whatever the connect error was.

This manifested as flaky `winn_pool_tests:pool_not_started_test/0` failures:

```
1) winn_pool_tests:pool_not_started_test/0
   Failure/Error: {exit,
                    {econnrefused,
                       {sys,terminate,[<0.3213.0>,normal,infinity]}},
```

The race was **latent before v0.9.1** — the previous code passed binary hosts to `gen_tcp:connect/4`, which rejected them with `badarg` before reaching the link-exit path. Fixing #145 (binary → charlist normalization) let epgsql actually attempt a real TCP connect, which unmasked the race.

**Fix:** `process_flag(trap_exit, true)` in `winn_pool:init/1`. The existing catch-all `handle_info/2` already silently drops any EXIT messages, so no handler additions needed. Also hardened `pool_not_started_test` to catch non-normal stop reasons and wait for the registered name to release before asserting.

I verified the behavior locally — running `epgsql:connect/1` against a dead port produces `{error, econnrefused}` cleanly plus a linked `gen_server` termination that sends an EXIT signal.

## Version bump

- `apps/winn/src/winn.app.src`, `winn_cli.erl`, `winn_repl.erl`, `winn_lsp.erl` → 0.9.2
- `CHANGELOG.md` — new `[0.9.2] - 2026-04-12` section covering both fixes
- `docs/roadmap.md` — current status + shipped table row
- `docs/getting-started.md` — version snippets

## Test plan
- [ ] CI passes on both OTP 27 and OTP 28
- [ ] `pool_not_started_test` stops flaking across reruns
- [ ] After merge: tag v0.9.2, cut release, verify .deb/.rpm build succeeds (fix #149 landed, so nfpm URL is now correct)
- [ ] Homebrew formula updated

## Related
- #145 — the original binary-host bug (fixed in v0.9.1, unmasked this race)
- #146 — v0.9.1 fix PR
- #149 — nfpm asset URL fix (already merged to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)