### PR TITLE
Add `pipeline` keyword — Broadway-shape supervised dataflow (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to the Winn language are documented here.
 ## [Unreleased]
 
 ### Language
+- **`pipeline` keyword** — Broadway-shape supervised multi-stage dataflow. Declare a `producer`, one `processor` (with configurable `concurrency`, `retry`, and per-message `timeout`), and an optional `batcher` (size + timeout flushing). Compiles to a supervisor tree with prefetch-driven backpressure, graceful drain on shutdown, and metrics published through the `Metrics` module. User-written producer modules implement a four-callback behaviour (`init/1`, `pull/2`, `ack/3`, `terminate/2`). See [docs/otp.md](docs/otp.md#pipeline). VS Code grammar update for `pipeline`, `producer`, `processor`, and `batcher` keywords will follow in a separate `language-winn-vscode` release. (#104)
 - **`private def`** — module-private functions. Functions declared with `private def name(...)` are callable from within the same module but excluded from the module's export list, so cross-module calls raise `undef`. Mirrors the existing `async def` modifier-before-`def` style. Multi-clause and guarded variants both supported. (#128)
+
+### Stdlib
+- **`Timer.sleep(ms)`** — block the calling process for `ms` milliseconds. Useful in top-level scripts that need to keep the VM alive after kicking off supervisor-backed work (e.g. `pipeline` demos).
 
 ### Developer Tooling
 - **LSP Phase 1 — lint diagnostics** — `winn lsp` now publishes lint warnings alongside compile errors. Each warning carries its rule name (e.g. `function_name_convention`) in the `code` field so editors can group and filter rules. Closing a document clears its diagnostics and removes it from the in-memory buffer. (#118)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 rebar3 compile              # Compile everything
-rebar3 eunit                # Run all 537 tests
+rebar3 eunit                # Run all 668 tests
 rebar3 eunit --module=winn_l1_tests  # Run a single test module
 rebar3 escriptize           # Build the winn CLI escript
 ./_build/default/bin/winn help       # Verify CLI works
@@ -59,6 +59,7 @@ All AST nodes are tagged tuples: `{Tag, Line, ...fields}`. No records. Key shape
 - `Logger` → `winn_logger`, `Crypto` → `winn_crypto`, `JSON` → `winn_json`
 - `HTTP` → `winn_http`, `Server` → `winn_server`, `Config` → `winn_config`
 - `Task` → `winn_task`, `JWT` → `winn_jwt`, `WS` → `winn_ws`
+- `Pipeline` → `winn_pipeline` (Broadway-shape dataflow runtime, backs the `pipeline` keyword)
 - `GenServer` → `gen_server`, `Supervisor` → `supervisor` (direct OTP)
 - `Winn` → `winn_runtime` (for `to_string` in interpolation)
 - Fallback: lowercase the module name

--- a/apps/winn/src/winn_codegen_resolve.erl
+++ b/apps/winn/src/winn_codegen_resolve.erl
@@ -51,6 +51,7 @@ resolve_dot_call('Protocol', Fun) -> {winn_protocol, Fun};
 resolve_dot_call('Health', Fun)   -> {winn_health, Fun};
 resolve_dot_call('Metrics', Fun)  -> {winn_metrics, Fun};
 resolve_dot_call('Agent', Fun)    -> {winn_agent, Fun};
+resolve_dot_call('Pipeline', Fun) -> {winn_pipeline, Fun};
 resolve_dot_call('ReplBindings', get) -> {winn_repl, get_binding};
 resolve_dot_call(Mod, Fun) ->
     ErlMod = list_to_atom(string:lowercase(atom_to_list(Mod))),

--- a/apps/winn/src/winn_lexer.xrl
+++ b/apps/winn/src/winn_lexer.xrl
@@ -38,6 +38,10 @@ Rules.
 %% Keywords — must appear before the identifier catch-all
 module                      : {token, {'module', TokenLine}}.
 agent                       : {token, {'agent', TokenLine}}.
+pipeline                    : {token, {'pipeline', TokenLine}}.
+producer                    : {token, {'producer', TokenLine}}.
+processor                   : {token, {'processor', TokenLine}}.
+batcher                     : {token, {'batcher', TokenLine}}.
 async                       : {token, {'async', TokenLine}}.
 private                     : {token, {'private', TokenLine}}.
 def                         : {token, {'def', TokenLine}}.

--- a/apps/winn/src/winn_parser.yrl
+++ b/apps/winn/src/winn_parser.yrl
@@ -17,6 +17,7 @@ Nonterminals
     top_forms top_form
     module_def module_body dotted_name
     agent_def agent_body agent_item agent_state_decl agent_function_def
+    pipeline_def pipeline_body pipeline_stage pipeline_opts pipeline_opt
     use_directive import_directive alias_directive
     function_def struct_def struct_fields protocol_def impl_def protocol_fns param_list pattern_list
     expr_seq
@@ -38,7 +39,7 @@ Nonterminals
 
 %% Phase 1 terminals + Phase 2 additions.
 Terminals
-    'module' 'agent' 'async' 'private' 'def' 'struct' 'protocol' 'impl' 'do' 'end' 'use' 'import' 'alias' 'schema' 'field'
+    'module' 'agent' 'pipeline' 'producer' 'processor' 'batcher' 'async' 'private' 'def' 'struct' 'protocol' 'impl' 'do' 'end' 'use' 'import' 'alias' 'schema' 'field'
     'match' 'ok_kw' 'err_kw' 'nil_kw'
     'if' 'else' 'switch' 'when' 'try' 'rescue'
     'fn' 'for' 'in'
@@ -66,6 +67,7 @@ top_forms -> top_form top_forms : ['$1' | '$2'].
 
 top_form -> module_def : '$1'.
 top_form -> agent_def  : '$1'.
+top_form -> pipeline_def : '$1'.
 
 %% ── Agent ────────────────────────────────────────────────────────────────────
 
@@ -93,6 +95,35 @@ agent_function_def -> 'def' ident '(' param_list ')' 'when' expr expr_seq 'end'
 %% Async (cast) function: async def log(msg) ... end
 agent_function_def -> 'async' 'def' ident '(' param_list ')' expr_seq 'end'
     : {agent_cast_fn, line('$1'), val('$3'), '$5', '$7'}.
+
+%% ── Pipeline ────────────────────────────────────────────────────────────────
+%% Broadway-shape supervised multi-stage dataflow:
+%%     pipeline Name
+%%       producer  :atom, key: value, ...
+%%       processor :atom, key: value, ... do |msg| body end
+%%       batcher   :atom, key: value, ... do |batch| body end
+%%     end
+
+pipeline_def -> 'pipeline' dotted_name pipeline_body 'end'
+    : {pipeline, line('$1'), '$2', '$3'}.
+
+pipeline_body -> '$empty'                          : [].
+pipeline_body -> pipeline_stage pipeline_body      : ['$1' | '$2'].
+
+pipeline_stage -> 'producer' atom_lit pipeline_opts
+    : {stage, line('$1'), producer, val('$2'), '$3', nobody}.
+
+pipeline_stage -> 'processor' atom_lit pipeline_opts 'do' block_params expr_seq 'end'
+    : {stage, line('$1'), processor, val('$2'), '$3', {'$5', '$6'}}.
+
+pipeline_stage -> 'batcher' atom_lit pipeline_opts 'do' block_params expr_seq 'end'
+    : {stage, line('$1'), batcher, val('$2'), '$3', {'$5', '$6'}}.
+
+%% Options are `, key: value` repeated. Empty list allowed.
+pipeline_opts -> '$empty'                           : [].
+pipeline_opts -> ',' pipeline_opt pipeline_opts     : ['$2' | '$3'].
+
+pipeline_opt -> ident ':' expr : {val('$1'), '$3'}.
 
 %% ── Module ─────────────────────────────────────────────────────────────────
 

--- a/apps/winn/src/winn_pipeline.erl
+++ b/apps/winn/src/winn_pipeline.erl
@@ -1,0 +1,500 @@
+%% winn_pipeline.erl
+%% Runtime for the `pipeline` keyword — Broadway-shape supervised dataflow.
+%%
+%% The generated pipeline module is itself a supervisor callback:
+%%   Generated start_link/0  -> winn_pipeline:start_link(?MOD, Spec)
+%%   Generated stop/0        -> winn_pipeline:stop(?MOD)
+%%   Generated stats/0       -> winn_pipeline:stats(?MOD)
+%%   Generated init/1        -> winn_pipeline:init(?MOD, Spec, Args)
+%%   Generated pipeline_spec/0 returns the map `Spec`.
+%%
+%% Topology (per pipeline; Name is the compiled module atom):
+%%
+%%     <Name>_sup (one_for_all, via the generated module as supervisor)
+%%     ├── <Name>_batcher       (gen_server, optional)
+%%     ├── <Name>_worker_1
+%%     ├── ...
+%%     ├── <Name>_worker_N
+%%     └── <Name>_producer      (gen_server; started LAST, stopped FIRST)
+%%
+%% Backpressure is prefetch-driven: the producer pulls up to `prefetch`
+%% items from the user's source module, distributes them round-robin to
+%% the worker pool, and waits for ack messages before pulling more.
+
+-module(winn_pipeline).
+
+%% Public API invoked by generated modules
+-export([start_link/2, stop/1, stats/1, init/3]).
+
+%% Producer / worker / batcher callbacks (gen_server)
+-export([producer_start_link/3, producer_init/1,
+         producer_handle_call/3, producer_handle_cast/2,
+         producer_handle_info/2, producer_terminate/2, producer_code_change/3]).
+
+-export([worker_start_link/4, worker_init/1,
+         worker_handle_call/3, worker_handle_cast/2,
+         worker_handle_info/2, worker_terminate/2, worker_code_change/3]).
+
+-export([batcher_start_link/3, batcher_init/1,
+         batcher_handle_call/3, batcher_handle_cast/2,
+         batcher_handle_info/2, batcher_terminate/2, batcher_code_change/3]).
+
+-behaviour(gen_server).
+
+%% The behaviour callbacks above are routed through per-role dispatch
+%% functions below; gen_server sees them as the standard 6 callbacks
+%% based on which start_link launched the process.
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(DEFAULT_PREFETCH,     10).
+-define(DEFAULT_CONCURRENCY,   1).
+-define(DEFAULT_RETRY,         0).
+-define(DEFAULT_TIMEOUT,       infinity).
+-define(DEFAULT_BATCH_SIZE,  100).
+-define(DEFAULT_BATCH_TO,   1000).
+-define(SHUTDOWN_TIMEOUT,   5000).
+
+%% ── Public API ────────────────────────────────────────────────────────────
+
+%% Start the pipeline supervisor. Generated module is its own sup callback.
+start_link(PipelineMod, _Spec) ->
+    supervisor:start_link({local, sup_name(PipelineMod)}, PipelineMod, []).
+
+%% Gracefully stop the pipeline (terminate in reverse order, drain naturally).
+stop(PipelineMod) ->
+    SupName = sup_name(PipelineMod),
+    case whereis(SupName) of
+        undefined -> ok;
+        Pid -> exit(Pid, shutdown), ok
+    end.
+
+%% Snapshot of per-pipeline metrics.
+stats(PipelineMod) ->
+    Prefix = atom_to_list(PipelineMod),
+    Keys = [processed, errors, retries, batch_flushes, in_flight],
+    maps:from_list([{K, safe_metric_get(Prefix ++ "." ++ atom_to_list(K))} || K <- Keys]).
+
+safe_metric_get(Key) ->
+    try winn_metrics:get(list_to_binary(Key))
+    catch _:_ -> 0
+    end.
+
+%% Supervisor init callback — builds child specs from the Spec map.
+init(PipelineMod, Spec, _Args) ->
+    BatcherChildren = case maps:find(batcher, Spec) of
+        error -> [];
+        {ok, BSpec} -> [batcher_child_spec(PipelineMod, BSpec)]
+    end,
+    ProcessorSpec = maps:get(processor, Spec),
+    Concurrency = maps:get(concurrency, ProcessorSpec, ?DEFAULT_CONCURRENCY),
+    BatcherName = case BatcherChildren of [] -> none; _ -> batcher_name(PipelineMod) end,
+    WorkerChildren = [worker_child_spec(PipelineMod, N, ProcessorSpec, BatcherName)
+                      || N <- lists:seq(1, Concurrency)],
+    ProducerSpec = maps:get(producer, Spec),
+    WorkerNames = [worker_name(PipelineMod, N) || N <- lists:seq(1, Concurrency)],
+    ProducerChild = producer_child_spec(PipelineMod, ProducerSpec, WorkerNames),
+
+    SupFlags = #{strategy => one_for_all, intensity => 3, period => 10},
+    Children = BatcherChildren ++ WorkerChildren ++ [ProducerChild],
+    {ok, {SupFlags, Children}}.
+
+%% ── Child specs ──────────────────────────────────────────────────────────
+
+batcher_child_spec(PipelineMod, BSpec) ->
+    #{id => batcher,
+      start => {?MODULE, batcher_start_link, [PipelineMod, BSpec, batcher_name(PipelineMod)]},
+      restart => permanent,
+      shutdown => ?SHUTDOWN_TIMEOUT,
+      type => worker,
+      modules => [?MODULE]}.
+
+worker_child_spec(PipelineMod, N, ProcessorSpec, BatcherName) ->
+    Name = worker_name(PipelineMod, N),
+    #{id => Name,
+      start => {?MODULE, worker_start_link, [PipelineMod, N, ProcessorSpec, BatcherName]},
+      restart => permanent,
+      shutdown => ?SHUTDOWN_TIMEOUT,
+      type => worker,
+      modules => [?MODULE]}.
+
+producer_child_spec(PipelineMod, ProducerSpec, WorkerNames) ->
+    #{id => producer,
+      start => {?MODULE, producer_start_link, [PipelineMod, ProducerSpec, WorkerNames]},
+      restart => permanent,
+      shutdown => ?SHUTDOWN_TIMEOUT,
+      type => worker,
+      modules => [?MODULE]}.
+
+%% ── Name helpers ─────────────────────────────────────────────────────────
+
+sup_name(PipelineMod) -> PipelineMod.
+producer_name(PipelineMod) -> list_to_atom(atom_to_list(PipelineMod) ++ "_producer").
+batcher_name(PipelineMod)  -> list_to_atom(atom_to_list(PipelineMod) ++ "_batcher").
+worker_name(PipelineMod, N) ->
+    list_to_atom(atom_to_list(PipelineMod) ++ "_worker_" ++ integer_to_list(N)).
+
+metric_key(PipelineMod, Suffix) ->
+    list_to_binary(atom_to_list(PipelineMod) ++ "." ++ Suffix).
+
+%% ── Generic gen_server shim ──────────────────────────────────────────────
+%% Each process identifies its role by the first element of its state tuple.
+
+init({producer, PipelineMod, ProducerSpec, WorkerNames}) ->
+    producer_init({PipelineMod, ProducerSpec, WorkerNames});
+init({worker, PipelineMod, N, ProcessorSpec, BatcherName}) ->
+    worker_init({PipelineMod, N, ProcessorSpec, BatcherName});
+init({batcher, PipelineMod, BSpec}) ->
+    batcher_init({PipelineMod, BSpec}).
+
+handle_call(Req, From, S = #{role := producer}) -> producer_handle_call(Req, From, S);
+handle_call(Req, From, S = #{role := worker})   -> worker_handle_call(Req, From, S);
+handle_call(Req, From, S = #{role := batcher})  -> batcher_handle_call(Req, From, S).
+
+handle_cast(Msg, S = #{role := producer}) -> producer_handle_cast(Msg, S);
+handle_cast(Msg, S = #{role := worker})   -> worker_handle_cast(Msg, S);
+handle_cast(Msg, S = #{role := batcher})  -> batcher_handle_cast(Msg, S).
+
+handle_info(Msg, S = #{role := producer}) -> producer_handle_info(Msg, S);
+handle_info(Msg, S = #{role := worker})   -> worker_handle_info(Msg, S);
+handle_info(Msg, S = #{role := batcher})  -> batcher_handle_info(Msg, S).
+
+terminate(R, S = #{role := producer}) -> producer_terminate(R, S);
+terminate(R, S = #{role := worker})   -> worker_terminate(R, S);
+terminate(R, S = #{role := batcher})  -> batcher_terminate(R, S).
+
+code_change(V, S = #{role := producer}, E) -> producer_code_change(V, S, E);
+code_change(V, S = #{role := worker},   E) -> worker_code_change(V, S, E);
+code_change(V, S = #{role := batcher},  E) -> batcher_code_change(V, S, E).
+
+%% ── Producer ─────────────────────────────────────────────────────────────
+
+producer_start_link(PipelineMod, ProducerSpec, WorkerNames) ->
+    gen_server:start_link({local, producer_name(PipelineMod)},
+                          ?MODULE,
+                          {producer, PipelineMod, ProducerSpec, WorkerNames},
+                          []).
+
+producer_init({PipelineMod, ProducerSpec, WorkerNames}) ->
+    process_flag(trap_exit, true),
+    Source    = maps:get(source, ProducerSpec),
+    Prefetch  = maps:get(prefetch, ProducerSpec, ?DEFAULT_PREFETCH),
+    UserOpts  = extract_user_opts(ProducerSpec),
+    UserMod   = resolve_user_mod(Source),
+    case safe_apply(UserMod, init, [UserOpts]) of
+        {ok, UserState} ->
+            State = #{role => producer,
+                      pipeline => PipelineMod,
+                      user_mod => UserMod,
+                      user_state => UserState,
+                      prefetch => Prefetch,
+                      workers => list_to_tuple(WorkerNames),
+                      cursor => 0,
+                      in_flight => 0,
+                      draining => false},
+            self() ! pull,
+            {ok, State};
+        {error, Reason} ->
+            {stop, {producer_init_failed, Reason}};
+        Other ->
+            {stop, {producer_init_bad_return, Other}}
+    end.
+
+%% Trim framework-only keys before calling user producer:init/1.
+extract_user_opts(ProducerSpec) ->
+    Framework = [name, source, prefetch],
+    maps:without(Framework, ProducerSpec).
+
+resolve_user_mod(Atom) when is_atom(Atom) ->
+    %% Winn PascalCase module names compile to lowercase atoms;
+    %% runtime may receive either. Try lowercased form first, fall back.
+    Lower = list_to_atom(string:lowercase(atom_to_list(Atom))),
+    case code:ensure_loaded(Lower) of
+        {module, Lower} -> Lower;
+        _ -> Atom
+    end.
+
+producer_handle_call(_Req, _From, State) ->
+    {reply, {error, unsupported}, State}.
+
+producer_handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+producer_handle_info(pull, State = #{draining := true}) ->
+    {noreply, State};
+producer_handle_info(pull, State) ->
+    #{user_mod := UserMod, user_state := UState,
+      prefetch := Prefetch, in_flight := InFlight,
+      workers := Workers, cursor := Cursor,
+      pipeline := Pipeline} = State,
+    Demand = max(0, Prefetch - InFlight),
+    case Demand of
+        0 -> {noreply, State};
+        _ ->
+            case safe_apply(UserMod, pull, [UState, Demand]) of
+                {ok, [], NewUState} ->
+                    %% No messages available; retry after a short pause.
+                    erlang:send_after(100, self(), pull),
+                    {noreply, State#{user_state := NewUState}};
+                {ok, Messages, NewUState} ->
+                    {NewCursor, _} = dispatch(Messages, Workers, Cursor, Pipeline),
+                    NewInFlight = InFlight + length(Messages),
+                    update_gauge(Pipeline, "in_flight", NewInFlight),
+                    {noreply, State#{user_state := NewUState,
+                                     cursor := NewCursor,
+                                     in_flight := NewInFlight}};
+                {error, Reason, NewUState} ->
+                    winn_logger:error(<<"pipeline producer pull failed">>,
+                                      #{pipeline => Pipeline, reason => format_reason(Reason)}),
+                    erlang:send_after(500, self(), pull),
+                    {noreply, State#{user_state := NewUState}}
+            end
+    end;
+producer_handle_info({ack, Message, Outcome}, State) ->
+    #{user_mod := UserMod, user_state := UState,
+      in_flight := InFlight, pipeline := Pipeline} = State,
+    NewUState = try
+        safe_apply(UserMod, ack, [UState, Message, Outcome])
+    catch
+        Class:Err ->
+            winn_logger:error(<<"pipeline producer ack raised">>,
+                              #{pipeline => Pipeline, class => Class,
+                                reason => format_reason(Err)}),
+            UState
+    end,
+    NewInFlight = max(0, InFlight - 1),
+    update_gauge(Pipeline, "in_flight", NewInFlight),
+    self() ! pull,
+    {noreply, State#{user_state := NewUState, in_flight := NewInFlight}};
+producer_handle_info(_, State) ->
+    {noreply, State}.
+
+producer_terminate(Reason, State = #{user_mod := UserMod, user_state := UState,
+                                     pipeline := Pipeline}) ->
+    %% Mark draining so subsequent pulls are no-ops if we get rescheduled.
+    drain_until_idle(State, 0),
+    try safe_apply(UserMod, terminate, [UState, Reason])
+    catch _:_ -> ok end,
+    winn_logger:info(<<"pipeline producer terminated">>,
+                     #{pipeline => Pipeline, reason => format_reason(Reason)}),
+    ok;
+producer_terminate(_Reason, _) -> ok.
+
+producer_code_change(_, State, _) -> {ok, State}.
+
+%% Dispatch messages round-robin across workers.
+%% Returns {NewCursor, SentCount}.
+dispatch([], _Workers, Cursor, _Pipeline) ->
+    {Cursor, 0};
+dispatch(Messages, Workers, Cursor, Pipeline) ->
+    dispatch_loop(Messages, Workers, Cursor, 0, Pipeline).
+
+dispatch_loop([], _Workers, Cursor, Count, _) ->
+    {Cursor, Count};
+dispatch_loop([Msg | Rest], Workers, Cursor, Count, Pipeline) ->
+    N = tuple_size(Workers),
+    WorkerName = element((Cursor rem N) + 1, Workers),
+    ProducerPid = self(),
+    gen_server:cast(WorkerName, {process, Msg, ProducerPid}),
+    dispatch_loop(Rest, Workers, Cursor + 1, Count + 1, Pipeline).
+
+drain_until_idle(#{in_flight := 0}, _) -> ok;
+drain_until_idle(_, Elapsed) when Elapsed >= ?SHUTDOWN_TIMEOUT -> ok;
+drain_until_idle(State, Elapsed) ->
+    receive
+        {ack, _, _} = Msg ->
+            {noreply, NewState} = producer_handle_info(Msg, State#{draining := true}),
+            drain_until_idle(NewState, Elapsed + 10)
+    after 100 ->
+        drain_until_idle(State, Elapsed + 100)
+    end.
+
+%% ── Worker ───────────────────────────────────────────────────────────────
+
+worker_start_link(PipelineMod, N, ProcessorSpec, BatcherName) ->
+    gen_server:start_link({local, worker_name(PipelineMod, N)},
+                          ?MODULE,
+                          {worker, PipelineMod, N, ProcessorSpec, BatcherName},
+                          []).
+
+worker_init({PipelineMod, N, ProcessorSpec, BatcherName}) ->
+    process_flag(trap_exit, true),
+    State = #{role => worker,
+              pipeline => PipelineMod,
+              index => N,
+              mod => maps:get(module, ProcessorSpec),
+              handler => maps:get(handler, ProcessorSpec),
+              retry => maps:get(retry, ProcessorSpec, ?DEFAULT_RETRY),
+              timeout => maps:get(timeout, ProcessorSpec, ?DEFAULT_TIMEOUT),
+              batcher => BatcherName},
+    {ok, State}.
+
+worker_handle_call(_Req, _From, State) ->
+    {reply, {error, unsupported}, State}.
+
+worker_handle_cast({process, Message, ProducerPid}, State) ->
+    #{mod := Mod, handler := H, retry := Retry, timeout := Timeout,
+      batcher := Batcher, pipeline := Pipeline} = State,
+    case run_handler(Mod, H, Message, Retry, Timeout, Pipeline) of
+        {ok, Result} ->
+            case Batcher of
+                none -> ok;
+                _    -> gen_server:cast(Batcher, {batch, Result})
+            end,
+            winn_metrics_incr(Pipeline, "processed"),
+            ProducerPid ! {ack, Message, ack},
+            {noreply, State};
+        {error, Reason} ->
+            winn_metrics_incr(Pipeline, "errors"),
+            winn_logger:error(<<"pipeline processor failed">>,
+                              #{pipeline => Pipeline,
+                                reason => format_reason(Reason)}),
+            ProducerPid ! {ack, Message, {nack, Reason}},
+            {noreply, State}
+    end;
+worker_handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+worker_handle_info(_Msg, State) -> {noreply, State}.
+
+worker_terminate(_Reason, _State) -> ok.
+
+worker_code_change(_, State, _) -> {ok, State}.
+
+%% Handler invocation with retry + optional timeout.
+run_handler(Mod, H, Message, Retry, Timeout, Pipeline) ->
+    Invoke = fun() ->
+        case Timeout of
+            infinity -> erlang:apply(Mod, H, [Message]);
+            Ms when is_integer(Ms) ->
+                Parent = self(),
+                Ref = make_ref(),
+                Pid = spawn(fun() ->
+                    R = try {ok, erlang:apply(Mod, H, [Message])}
+                        catch C:E:S -> {exception, C, E, S} end,
+                    Parent ! {Ref, R}
+                end),
+                receive
+                    {Ref, {ok, V}} -> V;
+                    {Ref, {exception, C, E, _}} -> erlang:C(E)
+                after Ms ->
+                    exit(Pid, kill),
+                    erlang:error({pipeline_handler_timeout, Ms})
+                end
+        end
+    end,
+    attempt(Invoke, Retry + 1, Pipeline, undefined).
+
+attempt(_F, 0, _Pipeline, LastErr) -> {error, LastErr};
+attempt(F, N, Pipeline, _LastErr) ->
+    try {ok, F()}
+    catch
+        Class:Reason:_Stack ->
+            case N of
+                1 -> {error, {Class, Reason}};
+                _ ->
+                    winn_metrics_incr(Pipeline, "retries"),
+                    attempt(F, N - 1, Pipeline, {Class, Reason})
+            end
+    end.
+
+%% ── Batcher ──────────────────────────────────────────────────────────────
+
+batcher_start_link(PipelineMod, BSpec, Name) ->
+    gen_server:start_link({local, Name},
+                          ?MODULE,
+                          {batcher, PipelineMod, BSpec},
+                          []).
+
+batcher_init({PipelineMod, BSpec}) ->
+    process_flag(trap_exit, true),
+    Size    = maps:get(size, BSpec, ?DEFAULT_BATCH_SIZE),
+    Timeout = maps:get(timeout, BSpec, ?DEFAULT_BATCH_TO),
+    State = #{role => batcher,
+              pipeline => PipelineMod,
+              mod => maps:get(module, BSpec),
+              handler => maps:get(handler, BSpec),
+              size => Size,
+              timeout => Timeout,
+              buffer => [],
+              timer => undefined},
+    {ok, State}.
+
+batcher_handle_call(_Req, _From, State) ->
+    {reply, {error, unsupported}, State}.
+
+batcher_handle_cast({batch, Item}, State) ->
+    #{buffer := Buf, size := Size} = State,
+    Buf1 = [Item | Buf],
+    State1 = State#{buffer := Buf1},
+    case length(Buf1) >= Size of
+        true  -> {noreply, flush(State1)};
+        false -> {noreply, arm_timer(State1)}
+    end;
+batcher_handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+batcher_handle_info(flush_timer, State) ->
+    {noreply, flush(State#{timer := undefined})};
+batcher_handle_info(_Msg, State) -> {noreply, State}.
+
+batcher_terminate(_Reason, State) ->
+    %% Drain any casts already in the mailbox before flushing so items
+    %% in flight at shutdown aren't lost.
+    State1 = drain_pending_batches(State),
+    _ = flush(State1),
+    ok.
+
+drain_pending_batches(State = #{buffer := Buf}) ->
+    receive
+        {'$gen_cast', {batch, Item}} ->
+            drain_pending_batches(State#{buffer := [Item | Buf]})
+    after 0 ->
+        State
+    end.
+
+batcher_code_change(_, State, _) -> {ok, State}.
+
+arm_timer(State = #{timer := undefined, timeout := T}) ->
+    Ref = erlang:send_after(T, self(), flush_timer),
+    State#{timer := Ref};
+arm_timer(State) -> State.
+
+flush(State = #{buffer := []}) ->
+    State;
+flush(State = #{buffer := Buf, mod := Mod, handler := H,
+                pipeline := Pipeline, timer := Timer}) ->
+    case Timer of
+        undefined -> ok;
+        _ -> erlang:cancel_timer(Timer)
+    end,
+    Batch = lists:reverse(Buf),
+    try
+        _ = erlang:apply(Mod, H, [Batch]),
+        winn_metrics_incr(Pipeline, "batch_flushes")
+    catch
+        Class:Reason ->
+            winn_logger:error(<<"pipeline batcher flush failed">>,
+                              #{pipeline => Pipeline, class => Class,
+                                reason => format_reason(Reason)})
+    end,
+    State#{buffer := [], timer := undefined}.
+
+%% ── Metrics helpers ──────────────────────────────────────────────────────
+
+winn_metrics_incr(Pipeline, Suffix) ->
+    try winn_metrics:increment(metric_key(Pipeline, Suffix))
+    catch _:_ -> ok end.
+
+update_gauge(Pipeline, Suffix, Value) ->
+    try winn_metrics:set(metric_key(Pipeline, Suffix), Value)
+    catch _:_ -> ok end.
+
+%% ── Misc helpers ─────────────────────────────────────────────────────────
+
+safe_apply(Mod, Fun, Args) ->
+    erlang:apply(Mod, Fun, Args).
+
+format_reason(R) ->
+    try iolist_to_binary(io_lib:format("~p", [R]))
+    catch _:_ -> <<"unknown">> end.

--- a/apps/winn/src/winn_timer.erl
+++ b/apps/winn/src/winn_timer.erl
@@ -1,5 +1,10 @@
 -module(winn_timer).
--export([every/3, 'after'/3, cancel/1]).
+-export([every/3, 'after'/3, cancel/1, sleep/1]).
+
+%% Timer.sleep(Ms) — block the calling process.
+sleep(Ms) when is_integer(Ms), Ms >= 0 ->
+    timer:sleep(Ms),
+    ok.
 
 %% Timer.every(N, :seconds/:ms, Fun)
 every(N, Unit, Fun) when is_function(Fun, 0) ->

--- a/apps/winn/src/winn_transform.erl
+++ b/apps/winn/src/winn_transform.erl
@@ -124,6 +124,42 @@ transform_form({agent, Line, Name, Items}) ->
               ++ [DefaultInfo, DefaultTerm],
     transform_form({module, Line, Name, ModuleBody});
 
+%% ── Pipeline: Broadway-style supervised dataflow ────────────────────────────
+%%
+%%   pipeline Name
+%%     producer  :atom, source: Mod, opt: val, ...
+%%     processor :atom, concurrency: N, retry: R, timeout: T do |msg| body end
+%%     batcher   :atom, size: S, timeout: T do |batch| body end
+%%   end
+%%
+%% Desugars to a supervisor module whose init/1 returns the sup flags and
+%% child specs produced by winn_pipeline:init/3. One handler function per
+%% processor/batcher stage holds the user's do-block body.
+transform_form({pipeline, Line, Name, Stages}) ->
+    {Producer, Processor, MaybeBatcher} = split_pipeline_stages(Stages, Line),
+    ModAtom = lower_module_atom(Name),
+
+    {ProcHandlerName, ProcHandlerFn} = gen_pipeline_handler(Processor, process),
+    {BatcherHandlerName, BatcherHandlerFns} =
+        case MaybeBatcher of
+            none -> {none, []};
+            _    -> {N, Fn} = gen_pipeline_handler(MaybeBatcher, batch), {N, [Fn]}
+        end,
+
+    SpecFn = gen_pipeline_spec_fn(Line, ModAtom,
+                                  Producer, Processor, ProcHandlerName,
+                                  MaybeBatcher, BatcherHandlerName),
+    StartLinkFn = gen_pipeline_wrapper(Line, start_link, ModAtom, true),
+    StopFn      = gen_pipeline_wrapper(Line, stop,       ModAtom, false),
+    StatsFn     = gen_pipeline_wrapper(Line, stats,      ModAtom, false),
+    InitFn      = gen_pipeline_init_fn(Line, ModAtom),
+    BehavAttr   = {behaviour_attr, Line, supervisor},
+
+    ModuleBody = [BehavAttr,
+                  StartLinkFn, StopFn, StatsFn, InitFn,
+                  SpecFn, ProcHandlerFn | BatcherHandlerFns],
+    transform_form({module, Line, Name, ModuleBody});
+
 transform_form(Other) ->
     Other.
 
@@ -170,6 +206,93 @@ expand_use(Line, 'Winn', 'Test', _ModName) ->
     {behaviour_only, Attr};
 expand_use(_Line, 'Winn', 'Schema', _ModName) ->
     {schema_use, none}.
+
+%% ── Pipeline helper functions ────────────────────────────────────────────
+
+%% Partition stages; enforce exactly 1 producer, 1 processor, 0..1 batcher.
+split_pipeline_stages(Stages, Line) ->
+    Producers  = [S || S = {stage, _, producer,  _, _, _} <- Stages],
+    Processors = [S || S = {stage, _, processor, _, _, _} <- Stages],
+    Batchers   = [S || S = {stage, _, batcher,   _, _, _} <- Stages],
+    case {length(Producers), length(Processors), length(Batchers)} of
+        {1, 1, BC} when BC =< 1 -> ok;
+        {0, _, _} -> erlang:error({pipeline_missing_producer, Line});
+        {_, 0, _} -> erlang:error({pipeline_missing_processor, Line});
+        {P, _, _} when P > 1 -> erlang:error({pipeline_multiple_producers, Line});
+        {_, P, _} when P > 1 -> erlang:error({pipeline_multiple_processors, Line});
+        {_, _, B} when B > 1 -> erlang:error({pipeline_multiple_batchers, Line})
+    end,
+    [Producer]  = Producers,
+    [Processor] = Processors,
+    MaybeBatcher = case Batchers of [] -> none; [Bat] -> Bat end,
+    {Producer, Processor, MaybeBatcher}.
+
+%% Emit a single-arg handler function holding the user's do-block body.
+%% Kind = process | batch; drives the generated name.
+gen_pipeline_handler({stage, L, Kind, Name, _Opts, Body}, ExpectedKind) ->
+    case {Kind, ExpectedKind} of
+        {processor, process} -> ok;
+        {batcher,   batch}   -> ok;
+        _ -> erlang:error({pipeline_handler_kind_mismatch, L, Kind, ExpectedKind})
+    end,
+    Prefix = case ExpectedKind of process -> "__pipeline_process_"; batch -> "__pipeline_batch_" end,
+    HandlerName = list_to_atom(Prefix ++ atom_to_list(Name) ++ "__"),
+    {BlockParams, BlockBody} = case Body of
+        {Ps, Bs} -> {Ps, Bs};
+        _ -> erlang:error({pipeline_handler_missing_body, L})
+    end,
+    Params = case BlockParams of
+        []      -> [{pat_wildcard, L}];
+        [P]     -> [P];
+        _       -> erlang:error({pipeline_handler_bad_arity, L})
+    end,
+    FinalBody = case BlockBody of [] -> [{atom, L, ok}]; _ -> BlockBody end,
+    Fn = {function, L, HandlerName, Params, FinalBody},
+    {HandlerName, Fn}.
+
+%% pipeline_spec/0 returns a map describing all stages.
+%% Producer opts pass through verbatim (runtime extracts framework keys).
+%% Processor/batcher spec gets {module, handler} for apply-based dispatch.
+gen_pipeline_spec_fn(L, ModAtom, Producer, Processor, ProcHandlerName, MaybeBatcher, BatcherHandlerName) ->
+    ProducerMap  = producer_spec_map(L, Producer),
+    ProcessorMap = worker_spec_map(L, ModAtom, Processor, ProcHandlerName),
+    BaseEntries  = [{producer, ProducerMap}, {processor, ProcessorMap}],
+    Entries = case MaybeBatcher of
+        none -> BaseEntries;
+        _    -> BaseEntries ++ [{batcher, worker_spec_map(L, ModAtom, MaybeBatcher, BatcherHandlerName)}]
+    end,
+    {function, L, pipeline_spec, [], [{map, L, Entries}]}.
+
+producer_spec_map(L, {stage, _, producer, Name, Opts, _}) ->
+    Entries = [{name, {atom, L, Name}} | Opts],
+    {map, L, Entries}.
+
+worker_spec_map(L, ModAtom, {stage, _, _Kind, Name, Opts, _}, HandlerName) ->
+    Entries = [{name, {atom, L, Name}},
+               {module, {atom, L, ModAtom}},
+               {handler, {atom, L, HandlerName}} | Opts],
+    {map, L, Entries}.
+
+%% start_link/0 -> Pipeline.start_link(:mod, pipeline_spec())
+%% stop/0       -> Pipeline.stop(:mod)
+%% stats/0      -> Pipeline.stats(:mod)
+%% WithSpec = true adds pipeline_spec() as second arg.
+gen_pipeline_wrapper(L, FnName, ModAtom, WithSpec) ->
+    Args = [{atom, L, ModAtom}] ++ case WithSpec of
+        true  -> [{call, L, pipeline_spec, []}];
+        false -> []
+    end,
+    Body = [{dot_call, L, 'Pipeline', FnName, Args}],
+    {function, L, FnName, [], Body}.
+
+%% init/1 -> Pipeline.init(:mod, pipeline_spec(), Args)
+gen_pipeline_init_fn(L, ModAtom) ->
+    Body = [{dot_call, L, 'Pipeline', init, [
+        {atom, L, ModAtom},
+        {call, L, pipeline_spec, []},
+        {var, L, args}
+    ]}],
+    {function, L, init, [{var, L, args}], Body}.
 
 %% ── Agent helper functions ──────────────────────────────────────────────
 

--- a/apps/winn/test/winn_pipeline_tests.erl
+++ b/apps/winn/test/winn_pipeline_tests.erl
@@ -1,0 +1,359 @@
+-module(winn_pipeline_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Helpers invoked by compiled pipeline modules as `Winn_pipeline_tests.*`.
+-export([record_batch/1, process_double/1, sleepy/1, flaky/1, forever/0]).
+
+%% Tests for the `pipeline` keyword: Broadway-shape supervised dataflow.
+%%
+%% Each test compiles a Winn pipeline definition, spins up a tiny
+%% in-memory producer pre-compiled in Erlang, starts the pipeline, and
+%% verifies end-to-end behaviour. A shared fixture (an ETS-backed list
+%% producer) stands in for the fleet-delivery AMQP source.
+
+%% ── Helpers ───────────────────────────────────────────────────────────────
+
+compile_and_load(Source) ->
+    {ok, Tokens, _} = winn_lexer:string(Source),
+    Filtered = winn_newline_filter:filter(Tokens),
+    {ok, AST} = winn_parser:parse(Filtered),
+    Transformed = winn_transform:transform(AST),
+    [CoreMod] = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+ensure_producer_loaded() ->
+    case code:is_loaded(pipetestproducer) of
+        {file, _} -> ok;
+        _ ->
+            compile_producer(),
+            ok
+    end.
+
+%% Dynamically compile the in-memory producer Erlang module on first use.
+compile_producer() ->
+    Src = producer_source(),
+    {ok, Forms} = parse_erl_forms(Src),
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    code:purge(Mod),
+    {module, Mod} = code:load_binary(Mod, "pipetestproducer.erl", Bin),
+    ok.
+
+parse_erl_forms(Src) ->
+    {ok, Tokens, _} = erl_scan:string(Src),
+    split_forms(Tokens, [], []).
+
+split_forms([], [], Acc) ->
+    {ok, lists:reverse(Acc)};
+split_forms([], Buf, Acc) ->
+    {ok, Form} = erl_parse:parse_form(lists:reverse(Buf)),
+    {ok, lists:reverse([Form | Acc])};
+split_forms([Tok = {dot, _} | Rest], Buf, Acc) ->
+    {ok, Form} = erl_parse:parse_form(lists:reverse([Tok | Buf])),
+    split_forms(Rest, [], [Form | Acc]);
+split_forms([Tok | Rest], Buf, Acc) ->
+    split_forms(Rest, [Tok | Buf], Acc).
+
+producer_source() ->
+    "-module(pipetestproducer).\n"
+    "-export([init/1, pull/2, ack/3, terminate/2, set_items/2, wait_acked/2, acked/1]).\n"
+    "init(Opts) ->\n"
+    "    Name = maps:get(fixture, Opts, default),\n"
+    "    case ets:whereis(Name) of\n"
+    "        undefined -> ets:new(Name, [public, set, named_table]);\n"
+    "        _ -> ok\n"
+    "    end,\n"
+    "    ensure_default(Name, items, []),\n"
+    "    ensure_default(Name, acked, 0),\n"
+    "    ensure_default(Name, nacks, 0),\n"
+    "    {ok, Name}.\n"
+    "ensure_default(T, K, V) ->\n"
+    "    case ets:lookup(T, K) of\n"
+    "        [] -> ets:insert(T, {K, V});\n"
+    "        _  -> ok\n"
+    "    end.\n"
+    "pull(T, Demand) ->\n"
+    "    [{items, Items}] = ets:lookup(T, items),\n"
+    "    Take = min(Demand, length(Items)),\n"
+    "    {Head, Rest} = lists:split(Take, Items),\n"
+    "    ets:insert(T, {items, Rest}),\n"
+    "    {ok, Head, T}.\n"
+    "ack(T, _Msg, ack) ->\n"
+    "    ets:update_counter(T, acked, 1),\n"
+    "    T;\n"
+    "ack(T, _Msg, {nack, _}) ->\n"
+    "    ets:update_counter(T, nacks, 1),\n"
+    "    T.\n"
+    "terminate(_T, _R) -> ok.\n"
+    "set_items(Name, Items) ->\n"
+    "    case ets:whereis(Name) of\n"
+    "        undefined -> ets:new(Name, [public, set, named_table]);\n"
+    "        _ -> ok\n"
+    "    end,\n"
+    "    ensure_default(Name, items, []),\n"
+    "    ensure_default(Name, acked, 0),\n"
+    "    ensure_default(Name, nacks, 0),\n"
+    "    ets:insert(Name, {items, Items}),\n"
+    "    ok.\n"
+    "acked(Name) ->\n"
+    "    case ets:lookup(Name, acked) of\n"
+    "        [{acked, N}] -> N;\n"
+    "        _ -> 0\n"
+    "    end.\n"
+    "wait_acked(Name, Target) -> wait_acked(Name, Target, 200).\n"
+    "wait_acked(Name, Target, 0) -> {timeout, acked(Name), Target};\n"
+    "wait_acked(Name, Target, N) ->\n"
+    "    case acked(Name) of\n"
+    "        V when V >= Target -> {ok, V};\n"
+    "        _ -> timer:sleep(20), wait_acked(Name, Target, N - 1)\n"
+    "    end.\n".
+
+%% Collector process for observing batcher output across tests.
+start_collector() ->
+    case ets:whereis(pipetest_sink) of
+        undefined -> ets:new(pipetest_sink, [public, set, named_table]);
+        _ -> ok
+    end,
+    ets:insert(pipetest_sink, {batches, []}),
+    ets:insert(pipetest_sink, {items, []}),
+    ok.
+
+sink_batches() ->
+    case ets:lookup(pipetest_sink, batches) of
+        [{batches, B}] -> lists:reverse(B);
+        _ -> []
+    end.
+
+sink_items() ->
+    case ets:lookup(pipetest_sink, items) of
+        [{items, I}] -> lists:reverse(I);
+        _ -> []
+    end.
+
+record_batch(Batch) ->
+    [{batches, Prev}] = ets:lookup(pipetest_sink, batches),
+    ets:insert(pipetest_sink, {batches, [Batch | Prev]}),
+    [{items, PItems}] = ets:lookup(pipetest_sink, items),
+    ets:insert(pipetest_sink, {items, lists:reverse(Batch) ++ PItems}),
+    ok.
+
+process_double(N) when is_integer(N) -> N * 2.
+
+start_and_wait(PipelineMod, Fixture, Target) ->
+    process_flag(trap_exit, true),
+    {ok, Sup} = PipelineMod:start_link(),
+    true = unlink(Sup),
+    Result = pipetestproducer:wait_acked(Fixture, Target),
+    stop_and_wait(PipelineMod),
+    Result.
+
+stop_and_wait(PipelineMod) ->
+    case whereis(PipelineMod) of
+        undefined -> ok;
+        Pid ->
+            MRef = erlang:monitor(process, Pid),
+            PipelineMod:stop(),
+            receive
+                {'DOWN', MRef, process, Pid, _} -> ok
+            after 5000 ->
+                erlang:demonitor(MRef, [flush]),
+                exit(Pid, kill),
+                ok
+            end
+    end.
+
+setup_fixture(Fixture, Items) ->
+    ensure_producer_loaded(),
+    start_collector(),
+    pipetestproducer:set_items(Fixture, Items),
+    ok.
+
+%% ── Tests ─────────────────────────────────────────────────────────────────
+
+%% 1. Compiles — smoke test: pipeline source produces a loadable module.
+compiles_test() ->
+    Mod = compile_and_load(
+        "pipeline Compiles1\n"
+        "  producer :src, source: PipetestProducer\n"
+        "  processor :work, concurrency: 1 do |m| m end\n"
+        "end\n"),
+    Exports = Mod:module_info(exports),
+    ?assert(lists:member({start_link, 0}, Exports)),
+    ?assert(lists:member({stop, 0}, Exports)),
+    ?assert(lists:member({stats, 0}, Exports)),
+    ?assert(lists:member({init, 1}, Exports)),
+    ?assert(lists:member({pipeline_spec, 0}, Exports)),
+    Spec = Mod:pipeline_spec(),
+    ?assertMatch(#{producer := _, processor := _}, Spec).
+
+%% 2. End-to-end — 30 messages through pipeline with batcher, assert all arrive.
+end_to_end_test() ->
+    setup_fixture(fixture_e2e, lists:seq(1, 30)),
+    Mod = compile_and_load(
+        "pipeline EndToEnd1\n"
+        "  producer :src, source: PipetestProducer, fixture: :fixture_e2e, prefetch: 10\n"
+        "  processor :work, concurrency: 2 do |n| Winn_pipeline_tests.process_double(n) end\n"
+        "  batcher :sink, size: 5, timeout: 500 do |batch| Winn_pipeline_tests.record_batch(batch) end\n"
+        "end\n"),
+    {ok, _} = start_and_wait(Mod, fixture_e2e, 30),
+    timer:sleep(200),
+    Items = sink_items(),
+    Expected = [N * 2 || N <- lists:seq(1, 30)],
+    ?assertEqual(lists:sort(Expected), lists:sort(Items)),
+    ok.
+
+%% 3. Concurrency — 20 messages through 4 workers; each worker takes 50ms;
+%%    must complete noticeably faster than serial (20*50=1000ms).
+concurrency_test() ->
+    setup_fixture(fixture_conc, lists:seq(1, 20)),
+    Mod = compile_and_load(
+        "pipeline Concur1\n"
+        "  producer :src, source: PipetestProducer, fixture: :fixture_conc, prefetch: 8\n"
+        "  processor :work, concurrency: 4 do |n|\n"
+        "    Winn_pipeline_tests.sleepy(n)\n"
+        "  end\n"
+        "end\n"),
+    T0 = erlang:monotonic_time(millisecond),
+    {ok, _} = start_and_wait(Mod, fixture_conc, 20),
+    Elapsed = erlang:monotonic_time(millisecond) - T0,
+    ?assert(Elapsed < 900, {too_slow, Elapsed}),
+    ok.
+
+sleepy(N) -> timer:sleep(50), N.
+
+%% 4. Retry — handler fails the first 2 attempts, succeeds on 3rd.
+retry_test() ->
+    setup_fixture(fixture_retry, [1, 2, 3]),
+    ensure_retry_counter(),
+    Mod = compile_and_load(
+        "pipeline Retry1\n"
+        "  producer :src, source: PipetestProducer, fixture: :fixture_retry, prefetch: 5\n"
+        "  processor :work, concurrency: 1, retry: 3 do |n|\n"
+        "    Winn_pipeline_tests.flaky(n)\n"
+        "  end\n"
+        "end\n"),
+    {ok, _} = start_and_wait(Mod, fixture_retry, 3),
+    %% Every message is attempted 3 times; 3 messages * 3 attempts = 9 total calls.
+    ?assertEqual(9, retry_total_calls()),
+    ok.
+
+ensure_retry_counter() ->
+    case ets:whereis(pipetest_retry) of
+        undefined -> ets:new(pipetest_retry, [public, set, named_table]);
+        _ -> ok
+    end,
+    ets:insert(pipetest_retry, {calls, 0}),
+    ets:insert(pipetest_retry, {fail_count, 2}),
+    ok.
+
+retry_total_calls() ->
+    [{calls, N}] = ets:lookup(pipetest_retry, calls),
+    N.
+
+flaky(N) ->
+    [{calls, C}] = ets:lookup(pipetest_retry, calls),
+    ets:insert(pipetest_retry, {calls, C + 1}),
+    %% Fail first 2 attempts per *instance* of the pipeline (not per message);
+    %% we just simulate transient errors and let retry resolve them.
+    Phase = (C rem 3),
+    case Phase of
+        2 -> N;  %% 3rd attempt (indices 0,1,2) succeeds
+        _ -> erlang:error(transient_fail)
+    end.
+
+%% 5. Timeout — handler sleeps past timeout; message is nacked.
+timeout_test() ->
+    setup_fixture(fixture_timeout, [1, 2]),
+    Mod = compile_and_load(
+        "pipeline Timeout1\n"
+        "  producer :src, source: PipetestProducer, fixture: :fixture_timeout, prefetch: 5\n"
+        "  processor :work, concurrency: 1, timeout: 50, retry: 0 do |_n|\n"
+        "    Winn_pipeline_tests.forever()\n"
+        "  end\n"
+        "end\n"),
+    process_flag(trap_exit, true),
+    {ok, Sup} = Mod:start_link(),
+    true = unlink(Sup),
+    {ok, _} = wait_nacked(fixture_timeout, 2),
+    stop_and_wait(Mod),
+    ?assertEqual(0, pipetestproducer:acked(fixture_timeout)),
+    [{nacks, N}] = ets:lookup(fixture_timeout, nacks),
+    ?assertEqual(2, N),
+    ok.
+
+wait_nacked(Fixture, Target) -> wait_nacked(Fixture, Target, 200).
+wait_nacked(Fixture, _Target, 0) ->
+    [{nacks, V}] = ets:lookup(Fixture, nacks),
+    {timeout, V};
+wait_nacked(Fixture, Target, N) ->
+    case ets:lookup(Fixture, nacks) of
+        [{nacks, V}] when V >= Target -> {ok, V};
+        _ -> timer:sleep(20), wait_nacked(Fixture, Target, N - 1)
+    end.
+
+forever() -> timer:sleep(5000).
+
+%% 6. Batcher size — 7 messages with size:3; expect 3 flushes (3, 3, 1).
+batcher_size_test() ->
+    setup_fixture(fixture_bsize, lists:seq(1, 7)),
+    Mod = compile_and_load(
+        "pipeline BSize1\n"
+        "  producer :src, source: PipetestProducer, fixture: :fixture_bsize, prefetch: 5\n"
+        "  processor :work, concurrency: 1 do |n| n end\n"
+        "  batcher :sink, size: 3, timeout: 10000 do |batch|\n"
+        "    Winn_pipeline_tests.record_batch(batch)\n"
+        "  end\n"
+        "end\n"),
+    {ok, _} = start_and_wait(Mod, fixture_bsize, 7),
+    timer:sleep(100),
+    Batches = sink_batches(),
+    Sizes = [length(B) || B <- Batches],
+    %% Two size-3 batches + a tail (1 item) flushed on terminate.
+    ?assert(lists:sum(Sizes) == 7, {batches, Batches}),
+    ?assert(lists:member(3, Sizes), {batches, Batches}),
+    ok.
+
+%% 7. Batcher timeout — 2 messages, wait for timer to fire.
+batcher_timeout_test() ->
+    setup_fixture(fixture_btime, [101, 102]),
+    Mod = compile_and_load(
+        "pipeline BTime1\n"
+        "  producer :src, source: PipetestProducer, fixture: :fixture_btime, prefetch: 5\n"
+        "  processor :work, concurrency: 1 do |n| n end\n"
+        "  batcher :sink, size: 100, timeout: 100 do |batch|\n"
+        "    Winn_pipeline_tests.record_batch(batch)\n"
+        "  end\n"
+        "end\n"),
+    process_flag(trap_exit, true),
+    {ok, Sup} = Mod:start_link(),
+    true = unlink(Sup),
+    {ok, _} = pipetestproducer:wait_acked(fixture_btime, 2),
+    timer:sleep(300),  %% let the batcher timer fire before stopping
+    ?assertMatch([_ | _], sink_batches()),
+    Flat = lists:flatten(sink_batches()),
+    ?assertEqual([101, 102], lists:sort(Flat)),
+    stop_and_wait(Mod),
+    ok.
+
+%% 8. Graceful shutdown — pending batch is flushed on terminate.
+graceful_shutdown_test() ->
+    setup_fixture(fixture_shutdown, [201, 202, 203]),
+    Mod = compile_and_load(
+        "pipeline Shut1\n"
+        "  producer :src, source: PipetestProducer, fixture: :fixture_shutdown, prefetch: 5\n"
+        "  processor :work, concurrency: 1 do |n| n end\n"
+        "  batcher :sink, size: 100, timeout: 60000 do |batch|\n"
+        "    Winn_pipeline_tests.record_batch(batch)\n"
+        "  end\n"
+        "end\n"),
+    process_flag(trap_exit, true),
+    {ok, Sup} = Mod:start_link(),
+    true = unlink(Sup),
+    {ok, _} = pipetestproducer:wait_acked(fixture_shutdown, 3),
+    stop_and_wait(Mod),
+    %% Batcher terminate should flush remaining 3 items.
+    Flat = lists:flatten(sink_batches()),
+    ?assertEqual([201, 202, 203], lists:sort(Flat)),
+    ok.

--- a/docs/otp.md
+++ b/docs/otp.md
@@ -66,6 +66,98 @@ IO.puts(Counter.value(counter))   # prints 100
 
 Use `agent` when you want clean stateful actors with minimal code. Use `use Winn.GenServer` when you need full control over OTP callbacks, custom `handle_info`, or process linking.
 
+## Pipeline
+
+The `pipeline` keyword builds Broadway-shape supervised dataflows: a single producer feeds a pool of concurrent processors, which can optionally funnel results into a batcher. Each stage is its own gen_server, the whole pipeline lives under one supervisor, and backpressure is driven by the producer's prefetch count.
+
+### Defining a Pipeline
+
+```winn
+pipeline FleetDelivery
+  producer :amqp,
+    source: FleetAmqpProducer,
+    queue: "fleet.events",
+    prefetch: 50
+
+  processor :default,
+    concurrency: 10,
+    retry: 3,
+    timeout: 5000 do |msg|
+    FleetService.process(msg)
+  end
+
+  batcher :mongo,
+    size: 100,
+    timeout: 1000 do |batch|
+    MongoClient.bulk_upsert(batch)
+  end
+end
+```
+
+### Using a Pipeline
+
+```winn
+FleetDelivery.start_link()   # starts the supervisor tree
+FleetDelivery.stats()        # %{processed: N, errors: N, retries: N, ...}
+FleetDelivery.stop()         # graceful drain
+```
+
+### The Producer Behaviour
+
+Pipelines don't ship with any built-in source — you write a module that implements a four-function callback set. Keep the module simple; the pipeline runtime handles supervision, metrics, and backpressure around it.
+
+| Callback | Purpose | Return |
+|---|---|---|
+| `init(opts)` | Open the upstream source (AMQP channel, DB cursor, file handle). | `{:ok, state}` or `{:error, reason}` |
+| `pull(state, demand)` | Fetch up to `demand` messages. Return fewer (or `[]`) if you want the runtime to retry after a short backoff. | `{:ok, messages, state}` or `{:error, reason, state}` |
+| `ack(state, message, outcome)` | Acknowledge a completed message upstream. `outcome` is `:ack` or `{:nack, reason}`. | new `state` |
+| `terminate(state, reason)` | Close the source cleanly. | `:ok` |
+
+All `opts` besides the framework keys (`source`, `prefetch`) pass through to `init/1` as a map.
+
+### Stage Options
+
+- `producer`:
+  - `source:` — **required**. The module implementing the producer behaviour.
+  - `prefetch:` — max messages in flight across the worker pool (default `10`).
+  - any other `key: value` pair is forwarded to `init/1`.
+- `processor`:
+  - `concurrency:` — number of parallel workers (default `1`).
+  - `retry:` — retry count on handler failure (default `0`, no retry).
+  - `timeout:` — per-message timeout in milliseconds (default `infinity`).
+- `batcher` (optional stage):
+  - `size:` — flush threshold (default `100`).
+  - `timeout:` — idle flush in milliseconds (default `1000`).
+
+### Supervision & Shutdown
+
+A pipeline `FleetDelivery` compiles to a supervisor whose tree looks like:
+
+```
+fleetdelivery (one_for_all)
+├── fleetdelivery_batcher      (optional)
+├── fleetdelivery_worker_1
+├── ...
+├── fleetdelivery_worker_N
+└── fleetdelivery_producer
+```
+
+On `stop/0` or SIGTERM the supervisor terminates children in reverse order — the producer stops pulling first, workers finish in-flight messages, and the batcher flushes any buffered items before exiting. Pending casts are drained from the batcher's mailbox before the final flush, so nothing sitting between stages gets lost.
+
+### Metrics
+
+The pipeline emits counters and a gauge through the `Metrics` module. Keys are namespaced by the pipeline's module name:
+
+- `<pipeline>.processed`
+- `<pipeline>.errors`
+- `<pipeline>.retries`
+- `<pipeline>.batch_flushes`
+- `<pipeline>.in_flight` (gauge)
+
+### Pipeline vs Raw GenServer + Task
+
+Reach for `pipeline` when you need Broadway semantics: bounded concurrency, prefetch backpressure, per-stage supervision, and clean shutdown — without hand-rolling a worker pool and drain protocol. Drop down to `use Winn.GenServer` + `Task.async_stream` when you need a push-based interface, multi-stage dispatch, or topologies the Broadway shape doesn't cover.
+
 ## GenServer
 
 A GenServer is a stateful process that handles synchronous calls and asynchronous casts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,6 +31,7 @@
 | [#58](https://github.com/gregwinn/winn-lang/issues/58) | Bounds checking | Safe defaults for runtime functions |
 | [#98](https://github.com/gregwinn/winn-lang/issues/98) | Parser conflicts | Resolve shift/reduce conflicts before v1.0 |
 | [#100](https://github.com/gregwinn/winn-lang/issues/100) | Transform hardening | Pass ordering tests and invariant docs |
+| [#104](https://github.com/gregwinn/winn-lang/issues/104) | **Pipelines** (shipped) | `pipeline` keyword — Broadway-shape producer/processor/batcher with prefetch backpressure and supervised drain (accelerated from v1.0 for Echolo `fleet_delivery`) |
 
 ### v1.0.0 — The Winn Platform
 
@@ -40,7 +41,6 @@
 | [#33](https://github.com/gregwinn/winn-lang/issues/33) | Distributed Events | `Event.emit` / `on :event do` across BEAM nodes, zero infrastructure |
 | [#34](https://github.com/gregwinn/winn-lang/issues/34) | Background Jobs | `use Winn.Job` with queues, retries, cron, live dashboard |
 | [#103](https://github.com/gregwinn/winn-lang/issues/103) | **Reactive events** | Language-level `on`/`emit` pub/sub built on BEAM distribution |
-| [#104](https://github.com/gregwinn/winn-lang/issues/104) | **Pipelines** | `pipeline` keyword — supervised multi-stage data flows with backpressure |
 | [#108](https://github.com/gregwinn/winn-lang/issues/108) | **Distributed clustering** | `Winn.connect(:node@host)` — agents, events, and pipelines auto-span nodes |
 
 ### Ecosystem

--- a/examples/pipeline_demo.winn
+++ b/examples/pipeline_demo.winn
@@ -1,0 +1,69 @@
+#| Pipeline keyword demo — Broadway-shape supervised dataflow.
+   Run with: winn run examples/pipeline_demo.winn
+
+   Uses an in-memory list producer that emits a fixed set of integers,
+   then returns [] on subsequent pulls. A 2-worker processor doubles
+   each value, and a size=4 batcher prints each flushed batch.
+|#
+
+module Main
+  def main()
+    IO.puts("Starting DemoPipeline...")
+    DemoPipeline.start_link()
+    Timer.sleep(2000)
+    IO.puts("Stats:")
+    IO.inspect(DemoPipeline.stats())
+    DemoPipeline.stop()
+    IO.puts("Done.")
+  end
+end
+
+pipeline DemoPipeline
+  producer :src,
+    source: ListProducer,
+    items: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    prefetch: 4
+
+  processor :double,
+    concurrency: 2 do |n|
+    n * 2
+  end
+
+  batcher :print,
+    size: 4,
+    timeout: 500 do |batch|
+    IO.puts("flushed batch:")
+    IO.inspect(batch)
+  end
+end
+
+module ListProducer
+  def init(opts)
+    items = Map.get(:items, opts)
+    agent_ref = ListProducerState.start(%{queue: items})
+    {:ok, agent_ref}
+  end
+
+  def pull(pid, _demand)
+    items = ListProducerState.drain(pid)
+    {:ok, items, pid}
+  end
+
+  def ack(pid, _msg, _outcome)
+    pid
+  end
+
+  def terminate(_pid, _reason)
+    :ok
+  end
+end
+
+agent ListProducerState
+  state queue = []
+
+  def drain()
+    items = @queue
+    @queue = []
+    items
+  end
+end


### PR DESCRIPTION
## Summary

- Add the `pipeline` keyword — Broadway-shape supervised dataflow with `producer`, `processor`, and optional `batcher` stages. Accelerates #104 from the v1.0 milestone to unblock the Echolo `fleet_delivery` consumer (context: #152 Option A).
- One new runtime module (`winn_pipeline`) wires up the supervisor tree, prefetch-driven backpressure, retry / timeout, round-robin worker dispatch, and a batcher that drains its mailbox + final-flushes on shutdown. Generated pipeline modules stay thin — they are themselves the supervisor callback module.
- Producers are user-written modules implementing a four-callback contract (`init/1`, `pull/2`, `ack/3`, `terminate/2`); the AMQP driver lives separately in `winn-amqp` (gregwinn/winn-amqp#1), so this PR ships the keyword + runtime + contract only.

## What's in it

### Surface syntax

```winn
pipeline FleetDelivery
  producer :amqp, source: AmqpProducer, queue: \"fleet.events\", prefetch: 50

  processor :default, concurrency: 10, retry: 3, timeout: 5000 do |msg|
    FleetService.process(msg)
  end

  batcher :mongo, size: 100, timeout: 1000 do |batch|
    MongoClient.bulk_upsert(batch)
  end
end

FleetDelivery.start_link()
FleetDelivery.stats()    # %{processed: N, errors: N, retries: N, batch_flushes: N, in_flight: N}
FleetDelivery.stop()
```

### Layers touched (mirroring `agent`)

- **Lexer** — 4 new keyword tokens (`pipeline`, `producer`, `processor`, `batcher`)
- **Parser** — one `pipeline_def` production with three stage forms. **0 new shift/reduce conflicts** (still 53, held steady against baseline)
- **Transform** — desugars `pipeline Name ... end` to a supervisor module: auto-generates `start_link/0`, `stop/0`, `stats/0`, `init/1`, a `pipeline_spec/0` returning the stage-options map, and one `__pipeline_process_*__` / `__pipeline_batch_*__` handler per stage
- **Codegen resolver** — `Pipeline` → `winn_pipeline`
- **Runtime (new)** — `winn_pipeline.erl` (~340 lines): producer / worker / batcher gen_servers share one module via role-dispatched `handle_*` callbacks; `trap_exit` in each init so `terminate/2` actually runs; batcher drains pending `{batch, _}` casts from its mailbox before flushing on shutdown
- **Stdlib** — added `Timer.sleep/1` (small gap needed by the demo script)

### Out of scope (tracked separately)

- AMQP producer implementation → `winn-amqp` (gregwinn/winn-amqp#1)
- Push-based `.push/1` entrypoint
- Multiple chained processor stages
- VS Code grammar update for the new keywords → follow-up in `language-winn-vscode`

## Test plan

- [x] `rebar3 eunit` — **668 tests, 0 failures** (8 new in `winn_pipeline_tests.erl`: compile, end-to-end, concurrency, retry, timeout, batcher size-triggered flush, batcher timeout-triggered flush, graceful shutdown)
- [x] `rebar3 compile` — clean, conflict count held at 53
- [x] `rebar3 escriptize` — CLI builds
- [x] `winn run examples/pipeline_demo.winn` — 10 items double → 3 batches → stats printed → clean exit
- [ ] Manual smoke against `winn-registry-api` or a `winn-amqp` wiring once it's ready (downstream, not blocking this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)