### PR TITLE
Add Metrics.prometheus() for built-in /metrics endpoint (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Winn language are documented here.
 
 ### Stdlib
 - **`Timer.sleep(ms)`** — block the calling process for `ms` milliseconds. Useful in top-level scripts that need to keep the VM alive after kicking off supervisor-backed work (e.g. `pipeline` demos).
+- **`Metrics.prometheus()`** — render the current metrics state as a Prometheus v0.0.4 text exposition binary. Counters, gauges, histograms (as summaries with `quantile="0.5|0.95|0.99"` labels), per-endpoint HTTP stats (`http_requests_total`, `http_errors_total`, `http_request_duration_ms`), and BEAM gauges (`beam_process_count`, `beam_memory_*_bytes`, `beam_uptime_ms`) all emit valid exposition format with `# TYPE` preambles. Float values use 3-decimal compact form. Lets a `/metrics` endpoint be one line of Winn (`Server.text(conn, Metrics.prometheus())`) — replaces the ~50-line Erlang exporter previously documented in the deployment guide. (#156)
 
 ### Developer Tooling
 - **LSP Phase 1 — lint diagnostics** — `winn lsp` now publishes lint warnings alongside compile errors. Each warning carries its rule name (e.g. `function_name_convention`) in the `code` field so editors can group and filter rules. Closing a document clears its diagnostics and removes it from the in-memory buffer. (#118)

--- a/apps/winn/src/winn_metrics.erl
+++ b/apps/winn/src/winn_metrics.erl
@@ -7,7 +7,7 @@
          observe/2, time/2,
          get/1, snapshot/0, reset/1, reset_all/0,
          http_snapshot/0, record_http/4,
-         beam_stats/0]).
+         beam_stats/0, prometheus/0]).
 
 -define(COUNTERS, winn_metrics_counters).
 -define(GAUGES, winn_metrics_gauges).
@@ -198,6 +198,88 @@ beam_stats() ->
       atom_limit => erlang:system_info(atom_limit),
       scheduler_count => erlang:system_info(schedulers),
       uptime_ms => erlang:monotonic_time(millisecond) - erlang:system_info(start_time)}.
+
+%% ── Prometheus Exposition Format ────────────────────────────────────────────
+%% Renders the current metrics state as a Prometheus v0.0.4 text exposition
+%% binary suitable for serving from a /metrics endpoint.
+
+prometheus() ->
+    Snap = snapshot(),
+    Http = http_snapshot(),
+    Beam = beam_stats(),
+    Lines =
+        counter_lines(maps:get(counters, Snap, #{}))
+        ++ gauge_lines(maps:get(gauges, Snap, #{}))
+        ++ histogram_lines(maps:get(histograms, Snap, #{}))
+        ++ http_lines(Http)
+        ++ beam_lines(Beam),
+    iolist_to_binary([lists:join($\n, Lines), $\n]).
+
+counter_lines(M) ->
+    maps:fold(fun(K, V, Acc) ->
+        N = prom_bin(K),
+        Acc ++ [<<"# TYPE ", N/binary, " counter">>,
+                <<N/binary, " ", (prom_bin(V))/binary>>]
+    end, [], M).
+
+gauge_lines(M) ->
+    maps:fold(fun(K, V, Acc) ->
+        N = prom_bin(K),
+        Acc ++ [<<"# TYPE ", N/binary, " gauge">>,
+                <<N/binary, " ", (prom_bin(V))/binary>>]
+    end, [], M).
+
+histogram_lines(M) ->
+    maps:fold(fun(K, Summary, Acc) ->
+        N = prom_bin(K),
+        P50 = prom_bin(maps:get(p50, Summary, 0)),
+        P95 = prom_bin(maps:get(p95, Summary, 0)),
+        P99 = prom_bin(maps:get(p99, Summary, 0)),
+        Cnt = prom_bin(maps:get(count, Summary, 0)),
+        Acc ++ [
+            <<"# TYPE ", N/binary, " summary">>,
+            <<N/binary, "{quantile=\"0.5\"} ",  P50/binary>>,
+            <<N/binary, "{quantile=\"0.95\"} ", P95/binary>>,
+            <<N/binary, "{quantile=\"0.99\"} ", P99/binary>>,
+            <<N/binary, "_count ", Cnt/binary>>
+        ]
+    end, [], M).
+
+http_lines(M) when map_size(M) =:= 0 -> [];
+http_lines(M) ->
+    Endpoints = maps:fold(fun(Key, Stats, Acc) ->
+        Label = <<"endpoint=\"", Key/binary, "\"">>,
+        Acc ++ [
+            <<"http_requests_total{", Label/binary, "} ",
+              (prom_bin(maps:get(count, Stats)))/binary>>,
+            <<"http_errors_total{",   Label/binary, "} ",
+              (prom_bin(maps:get(errors, Stats)))/binary>>,
+            <<"http_request_duration_ms{", Label/binary, ",quantile=\"0.95\"} ",
+              (prom_bin(maps:get(p95_ms, Stats)))/binary>>
+        ]
+    end, [], M),
+    [<<"# TYPE http_requests_total counter">>,
+     <<"# TYPE http_errors_total counter">>,
+     <<"# TYPE http_request_duration_ms summary">>] ++ Endpoints.
+
+beam_lines(B) ->
+    [
+        <<"# TYPE beam_process_count gauge">>,
+        <<"beam_process_count ",          (prom_bin(maps:get(process_count, B)))/binary>>,
+        <<"# TYPE beam_memory_total_bytes gauge">>,
+        <<"beam_memory_total_bytes ",     (prom_bin(maps:get(memory_total, B)))/binary>>,
+        <<"# TYPE beam_memory_processes_bytes gauge">>,
+        <<"beam_memory_processes_bytes ", (prom_bin(maps:get(memory_processes, B)))/binary>>,
+        <<"# TYPE beam_memory_ets_bytes gauge">>,
+        <<"beam_memory_ets_bytes ",       (prom_bin(maps:get(memory_ets, B)))/binary>>,
+        <<"# TYPE beam_uptime_ms gauge">>,
+        <<"beam_uptime_ms ",              (prom_bin(maps:get(uptime_ms, B)))/binary>>
+    ].
+
+prom_bin(V) when is_binary(V)  -> V;
+prom_bin(V) when is_atom(V)    -> atom_to_binary(V, utf8);
+prom_bin(V) when is_integer(V) -> integer_to_binary(V);
+prom_bin(V) when is_float(V)   -> float_to_binary(V, [{decimals, 3}, compact]).
 
 %% ── Internal ────────────────────────────────────────────────────────────────
 

--- a/apps/winn/test/winn_metrics_tests.erl
+++ b/apps/winn/test/winn_metrics_tests.erl
@@ -110,6 +110,80 @@ reset_all_test() ->
     ?assertEqual(0, winn_metrics:get(a)),
     ?assertEqual(0, winn_metrics:get(b)).
 
+%% ── Prometheus exposition format (#156) ─────────────────────────────────────
+
+prometheus_contains(Output, Substr) ->
+    binary:match(Output, list_to_binary(Substr)) =/= nomatch.
+
+prometheus_counter_test() ->
+    setup(),
+    winn_metrics:increment(orders_total, 3),
+    Out = winn_metrics:prometheus(),
+    ?assert(prometheus_contains(Out, "# TYPE orders_total counter")),
+    ?assert(prometheus_contains(Out, "orders_total 3")).
+
+prometheus_gauge_test() ->
+    setup(),
+    winn_metrics:set(queue_depth, 7),
+    Out = winn_metrics:prometheus(),
+    ?assert(prometheus_contains(Out, "# TYPE queue_depth gauge")),
+    ?assert(prometheus_contains(Out, "queue_depth 7")).
+
+prometheus_histogram_test() ->
+    setup(),
+    winn_metrics:observe(request_ms, 10),
+    winn_metrics:observe(request_ms, 20),
+    Out = winn_metrics:prometheus(),
+    ?assert(prometheus_contains(Out, "# TYPE request_ms summary")),
+    ?assert(prometheus_contains(Out, "request_ms{quantile=\"0.5\"}")),
+    ?assert(prometheus_contains(Out, "request_ms{quantile=\"0.95\"}")),
+    ?assert(prometheus_contains(Out, "request_ms{quantile=\"0.99\"}")),
+    ?assert(prometheus_contains(Out, "request_ms_count 2")).
+
+prometheus_http_labels_test() ->
+    setup(),
+    winn_metrics:record_http(<<"GET">>, <<"/users">>, 200, 5),
+    winn_metrics:record_http(<<"GET">>, <<"/users">>, 500, 12),
+    Out = winn_metrics:prometheus(),
+    ?assert(prometheus_contains(Out, "# TYPE http_requests_total counter")),
+    ?assert(prometheus_contains(Out, "# TYPE http_request_duration_ms summary")),
+    ?assert(prometheus_contains(Out, "http_requests_total{endpoint=\"GET /users\"} 2")),
+    ?assert(prometheus_contains(Out, "http_errors_total{endpoint=\"GET /users\"} 1")),
+    ?assert(prometheus_contains(Out, "http_request_duration_ms{endpoint=\"GET /users\",quantile=\"0.95\"}")).
+
+prometheus_beam_stats_test() ->
+    setup(),
+    Out = winn_metrics:prometheus(),
+    ?assert(prometheus_contains(Out, "# TYPE beam_process_count gauge")),
+    ?assert(prometheus_contains(Out, "beam_process_count ")),
+    ?assert(prometheus_contains(Out, "beam_memory_total_bytes ")),
+    ?assert(prometheus_contains(Out, "beam_memory_processes_bytes ")),
+    ?assert(prometheus_contains(Out, "beam_memory_ets_bytes ")),
+    ?assert(prometheus_contains(Out, "beam_uptime_ms ")).
+
+%% Float values use 3-decimal compact form so trailing zeros never appear.
+prometheus_float_compact_test() ->
+    setup(),
+    winn_metrics:observe(latency, 12.3),
+    Out = winn_metrics:prometheus(),
+    ?assert(prometheus_contains(Out, "latency{quantile=\"0.5\"} 12.3")),
+    ?assertEqual(nomatch, binary:match(Out, <<"12.300">>)).
+
+%% Output is a valid binary, ends in a newline, and starts with no leading
+%% whitespace — basic shape Prometheus scrapers expect.
+prometheus_shape_test() ->
+    setup(),
+    Out = winn_metrics:prometheus(),
+    ?assert(is_binary(Out)),
+    ?assertEqual($\n, binary:last(Out)),
+    ?assertNotEqual(<<" ">>, binary:part(Out, 0, 1)).
+
+%% Empty HTTP map → no http_* lines (avoids emitting orphan TYPE lines).
+prometheus_no_http_when_empty_test() ->
+    setup(),
+    Out = winn_metrics:prometheus(),
+    ?assertEqual(nomatch, binary:match(Out, <<"http_requests_total">>)).
+
 %% ── End-to-end: Metrics from Winn source ───────────────────────────────────
 
 metrics_from_winn_test() ->
@@ -133,3 +207,26 @@ metrics_from_winn_test() ->
     {module, ModName} = code:load_binary(ModName, "test", Bin),
     Result = ModName:run(),
     ?assertEqual(2, Result).
+
+%% End-to-end: a Winn handler can call Metrics.prometheus() (#156).
+prometheus_from_winn_test() ->
+    setup(),
+    winn_metrics:increment(orders_total, 5),
+    winn_metrics:set(queue_depth, 3),
+    Source = "module PromTest\n"
+             "  def run()\n"
+             "    Metrics.prometheus()\n"
+             "  end\n"
+             "end\n",
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST} = winn_parser:parse(Tokens),
+    Transformed = winn_transform:transform(AST),
+    [CoreMod] = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    Result = ModName:run(),
+    ?assert(is_binary(Result)),
+    ?assert(binary:match(Result, <<"orders_total 5">>) =/= nomatch),
+    ?assert(binary:match(Result, <<"queue_depth 3">>) =/= nomatch).

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -332,6 +332,73 @@ data.count  # => 5
 
 ---
 
+## Metrics
+
+Counters, gauges, histograms, and HTTP request stats. ETS-backed for concurrent reads with no locking. Combine with `winn_logger` to get observability comparable to a typical production OTP service.
+
+Call `Metrics.enable()` once at app start (the CLI's `start` command does this automatically) before recording metrics.
+
+### `Metrics.increment(name)` / `Metrics.increment(name, amount)`
+Increment a counter. `amount` defaults to 1.
+```winn
+Metrics.increment(:requests)
+Metrics.increment(:bytes_sent, 1024)
+```
+
+### `Metrics.set(name, value)`
+Set a gauge to an absolute value.
+```winn
+Metrics.set(:queue_depth, 42)
+```
+
+### `Metrics.observe(name, value)`
+Record a sample in a histogram (e.g. for latency tracking). The most recent 1000 samples are retained per name.
+```winn
+Metrics.observe(:request_ms, 12.5)
+```
+
+### `Metrics.time(name, fun)`
+Time the execution of a zero-arity lambda and `observe` the elapsed milliseconds. Returns the lambda's result.
+```winn
+result = Metrics.time(:db_query, fn -> Repo.all(User) end)
+```
+
+### `Metrics.get(name)`
+Read a counter or gauge by name. Returns `0` if not found.
+```winn
+Metrics.get(:requests)  # => 42
+```
+
+### `Metrics.snapshot()`
+Return a map with all counters, gauges, and histogram summaries (`p50`, `p95`, `p99`, `count`, `avg`, `min`, `max`).
+```winn
+%{counters: counters, gauges: gauges, histograms: hist} = Metrics.snapshot()
+```
+
+### `Metrics.beam_stats()`
+Process count, memory breakdown, atom counts, scheduler count, and uptime — useful for runtime diagnostics dashboards.
+
+### `Metrics.prometheus()`
+Render the full metrics state as a Prometheus v0.0.4 text exposition binary. Wire it into a `/metrics` endpoint with one line:
+
+```winn
+module MyApp.Router
+  use Winn.Router
+
+  def routes()
+    [{:get, "/metrics", :metrics}]
+  end
+
+  def metrics(conn)
+    Server.text(conn, Metrics.prometheus())
+  end
+end
+```
+
+Output covers counters, gauges, histograms (as Prometheus summaries with `quantile="0.5|0.95|0.99"` labels), per-endpoint HTTP stats (`http_requests_total`, `http_errors_total`, `http_request_duration_ms`), and BEAM gauges (`beam_process_count`, `beam_memory_*_bytes`, `beam_uptime_ms`). Float values use 3-decimal compact form. See [deployment.md](deployment.md) for the full Prometheus + Kubernetes wiring.
+
+---
+
 ## Type Conversions
 
 These are available as bare function calls anywhere in Winn code:


### PR DESCRIPTION
Closes #156.

## Summary

Renders the full `winn_metrics` state — counters, gauges, histograms, per-endpoint HTTP stats, and BEAM gauges — as a Prometheus v0.0.4 text exposition binary. Routes through the existing `Metrics → winn_metrics` clause in `winn_codegen_resolve`, so a Winn `/metrics` handler is one line:

\`\`\`winn
def metrics(conn)
  Server.text(conn, Metrics.prometheus())
end
\`\`\`

Retires the ~50-line `metricsprometheus.erl` helper documented in PR #155's deployment guide — the only place winn docs told users to drop an `.erl` file into a Winn project.

## What changed

| File | Change |
|---|---|
| `apps/winn/src/winn_metrics.erl` | New `prometheus/0` + helpers (`counter_lines/1`, `gauge_lines/1`, `histogram_lines/1`, `http_lines/1`, `beam_lines/1`, `prom_bin/1`) |
| `apps/winn/test/winn_metrics_tests.erl` | +9 tests covering each metric type, HTTP labels, BEAM gauges, float-compact formatting, output shape, empty-HTTP edge case, and end-to-end via Winn source |
| `docs/stdlib.md` | New Metrics section documenting `enable/0`, `increment/1,2`, `set/2`, `observe/2`, `time/2`, `get/1`, `snapshot/0`, `beam_stats/0`, `prometheus/0` (the module previously had no reference page) |
| `CHANGELOG.md` | `[Unreleased]` Stdlib entry referencing #156 |

## Output format

Sample (against a live `winn_metrics`):

\`\`\`
# TYPE orders_total counter
orders_total 3
# TYPE queue_depth gauge
queue_depth 7
# TYPE request_ms summary
request_ms{quantile="0.5"} 10
request_ms{quantile="0.95"} 12.3
request_ms{quantile="0.99"} 12.3
request_ms_count 2
# TYPE http_requests_total counter
# TYPE http_errors_total counter
# TYPE http_request_duration_ms summary
http_requests_total{endpoint="GET /users"} 1
http_errors_total{endpoint="GET /users"} 0
http_request_duration_ms{endpoint="GET /users",quantile="0.95"} 5
# TYPE beam_process_count gauge
beam_process_count 143
# TYPE beam_memory_total_bytes gauge
beam_memory_total_bytes 53485296
…
\`\`\`

## Notes

- The `# TYPE` preambles for HTTP names (counter / summary) are emitted once per name, not per endpoint — keeps the format valid when many endpoints share the same metric.
- Empty HTTP snapshot → no `http_*` lines (avoids orphan TYPE preambles).
- Histogram quantile labels are unquoted floats per Prometheus convention (`quantile="0.5"`, not `"0.50"`).

## Test plan

- [x] \`rebar3 eunit\` — 685 tests passing (+9 new)
- [x] All metric types render correctly with TYPE preambles
- [x] HTTP labels properly quoted: \`endpoint="GET /users"\`
- [x] Quantile labels properly quoted: \`{quantile="0.95"}\`
- [x] Float values use 3-decimal compact form (12.3, not 12.300)
- [x] Output is a binary, ends with newline
- [x] Empty HTTP snapshot doesn't emit orphan \`# TYPE\` lines
- [x] End-to-end: \`Metrics.prometheus()\` from Winn source returns expected binary

## Follow-up for PR #155

Once this lands, the deployment guide can drop \`metricsprometheus.erl\` and the \`MetricsEndpoint\` proxy module, simplifying the Prometheus section to ~3 lines. PR #158 (string escapes, #157) covers the other half of the cleanup — letting that guide's inline Winn examples use \`\"\` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)