### PR TITLE
Hotfix 0.9.3: fix duplicate `_` wildcard rejected by core_lint (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Winn language are documented here.
 
+## [0.9.3] - 2026-06-10
+
+### Fixes
+- **Repeated `_` wildcard in a function head or pattern now compiles** ([#170](https://github.com/gregwinn/winn-lang/issues/170)) — codegen emitted the literal Core Erlang variable `'_'` for every wildcard, so any head/pattern with more than one (e.g. `def head_or([x | _], _)`) was rejected by `core_lint` with `{duplicate_var,'_',...}`. Each `_` is now freshened to a distinct anonymous variable, matching Erlang semantics where repeated `_` is valid. Affects `gen_param`/`gen_pattern` in `winn_codegen_pattern.erl`.
+
 ## [0.9.2] - 2026-04-12
 
 ### Fixes

--- a/apps/winn/src/winn.app.src
+++ b/apps/winn/src/winn.app.src
@@ -1,6 +1,6 @@
 {application, winn, [
     {description, "The Winn programming language compiler"},
-    {vsn, "0.9.2"},
+    {vsn, "0.9.3"},
     {registered, []},
     {applications, [kernel, stdlib, compiler, cowboy, jsone]},
     {env, []},

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -1076,7 +1076,7 @@ is_tty() ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.2"
+        _         -> "0.9.3"
     end.
 
 print_version() ->

--- a/apps/winn/src/winn_codegen_pattern.erl
+++ b/apps/winn/src/winn_codegen_pattern.erl
@@ -13,7 +13,7 @@
 %% After Phase 2 transform, params are always simple variables.
 
 gen_param({var, _, Name})        -> cerl:c_var(var_atom(Name));
-gen_param({pat_wildcard, _})     -> cerl:c_var('_');
+gen_param({pat_wildcard, _})     -> cerl:c_var(fresh_wildcard());
 gen_param({pat_var, _, Name})    -> cerl:c_var(var_atom(Name)).  %% defensive
 
 %% ── Patterns ─────────────────────────────────────────────────────────────
@@ -28,7 +28,7 @@ gen_pattern({pat_var, _Line, Name}) ->
     cerl:c_var(var_atom(Name));
 
 gen_pattern({pat_wildcard, _Line}) ->
-    cerl:c_var('_');
+    cerl:c_var(fresh_wildcard());
 
 gen_pattern({pat_atom, _Line, Value}) ->
     cerl:c_atom(Value);
@@ -48,3 +48,10 @@ gen_pattern({pat_list, _Line, [H | T], Tail}) ->
 
 gen_pattern(Unknown) ->
     error({unsupported_pattern_node, Unknown}).
+
+%% Each `_` wildcard must become a *distinct* Core Erlang variable. Emitting the
+%% literal `'_'` for every wildcard made core_lint reject any pattern/head with
+%% more than one (`{duplicate_var,'_',...}`). A fresh unique name per occurrence
+%% is anonymous in effect (it binds nothing the body uses) and lint-clean. (#170)
+fresh_wildcard() ->
+    list_to_atom("_W" ++ integer_to_list(erlang:unique_integer([monotonic, positive]))).

--- a/apps/winn/src/winn_repl.erl
+++ b/apps/winn/src/winn_repl.erl
@@ -230,5 +230,5 @@ get_binding(Name) when is_list(Name) ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.2"
+        _         -> "0.9.3"
     end.

--- a/apps/winn/test/winn_wildcard_tests.erl
+++ b/apps/winn/test/winn_wildcard_tests.erl
@@ -1,0 +1,57 @@
+%% winn_wildcard_tests.erl — regression tests for repeated `_` wildcards (#170).
+%%
+%% Each `_` must compile to a distinct Core Erlang variable; emitting the literal
+%% `'_'` for every wildcard made core_lint reject any pattern/head with more than
+%% one (`{duplicate_var,'_',...}`).
+
+-module(winn_wildcard_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_and_load(Source) ->
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% Two `_` across one function head (the originally reported repro).
+repeated_wildcard_in_head_test() ->
+    Src = "module DupWildHead\n"
+          "  def head_or([x | _], _)\n"
+          "    x\n"
+          "  end\n"
+          "  def head_or(_list, fallback)\n"
+          "    fallback\n"
+          "  end\n"
+          "end\n",
+    Mod = compile_and_load(Src),
+    ?assertEqual(1, Mod:head_or([1, 2, 3], 0)),
+    ?assertEqual(0, Mod:head_or([], 0)).
+
+%% Two `_` inside a single tuple pattern.
+repeated_wildcard_in_tuple_test() ->
+    Src = "module DupWildTuple\n"
+          "  def third({_, _, c})\n"
+          "    c\n"
+          "  end\n"
+          "end\n",
+    Mod = compile_and_load(Src),
+    ?assertEqual(3, Mod:third({1, 2, 3})).
+
+%% Wildcards in a switch clause pattern alongside a head wildcard.
+repeated_wildcard_in_switch_test() ->
+    Src = "module DupWildSwitch\n"
+          "  def tag(_ignored, pair)\n"
+          "    switch pair\n"
+          "      {_, _} => :two\n"
+          "      _ => :other\n"
+          "    end\n"
+          "  end\n"
+          "end\n",
+    Mod = compile_and_load(Src),
+    ?assertEqual(two, Mod:tag(0, {1, 2})),
+    ?assertEqual(other, Mod:tag(0, 5)).


### PR DESCRIPTION
## Summary

**Hotfix release 0.9.3.** Fixes #170 — `core_lint` rejected any function head or
pattern that used the bare `_` wildcard more than once
(`{duplicate_var,'_',{head_or,2}}`).

Codegen emitted the literal Core Erlang variable `'_'` for *every* wildcard, so two
of them in one scope collided. Each `_` is now freshened to a distinct anonymous
variable, matching Erlang where repeated `_` is valid.

```winn
def head_or([x | _], _)   # used to fail core_lint; now compiles
  x
end
def head_or(_list, fallback)
  fallback
end
```

## Changes

- `winn_codegen_pattern.erl` — `gen_param`/`gen_pattern` wildcard cases now emit a
  fresh unique variable (`fresh_wildcard/0`) instead of `'_'`.
- `winn_wildcard_tests.erl` — regression tests: repeated `_` in a function head, in a
  tuple pattern, and in a switch clause (all compile + run).
- Version bump **0.9.2 → 0.9.3** (`winn.app.src`, `winn_cli.erl`, `winn_repl.erl`).
- CHANGELOG `[0.9.3]` entry.

## Testing

- `winn run` on the original repro prints `1` then `0` (was a compile error).
- `rebar3 eunit`: 645 tests, only the pre-existing `winn_sqlite_tests` esqlite-NIF
  environmental failure remains (unrelated).

## Base

Branched off `v0.9.2` (== `main`), so this PR is exactly the one hotfix commit. After
merge: tag `v0.9.3`, GitHub release, Homebrew formula bump. The fix also needs porting
to `develop` (which diverged before 0.9.1/0.9.2).

Closes #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
