### PR TITLE
Fix release workflow: gzip -kf so apt Packages.gz overwrites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           cd apt-repo
           mkdir -p dists/stable/main/binary-amd64
           dpkg-scanpackages pool/ /dev/null > dists/stable/main/binary-amd64/Packages
-          gzip -k dists/stable/main/binary-amd64/Packages
+          gzip -kf dists/stable/main/binary-amd64/Packages
           cat > dists/stable/Release <<EOF
           Origin: Winn
           Label: Winn


### PR DESCRIPTION
The `update-apt-repo` job runs `gzip -k dists/stable/main/binary-amd64/Packages`, which refuses to overwrite the `Packages.gz` committed by a prior release and exits 2 under `bash -e` — failing the job. It passed at v0.9.2 (first release to create the file) but broke the v0.9.3 release ([run](https://github.com/gregwinn/winn-lang/actions/runs/27252625685)). Adding `-f` regenerates the gzipped index each release.

```diff
- gzip -k dists/stable/main/binary-amd64/Packages
+ gzip -kf dists/stable/main/binary-amd64/Packages
```

The GitHub release, binary, .deb/.rpm, and Homebrew all published fine for v0.9.3; only the APT index was affected. The v0.9.3 apt entry is being republished separately by clearing the stale `Packages.gz` and re-running the failed job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)