### PR TITLE
Release 0.9.4 — configurable HTTP timeouts (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Winn language are documented here.
 
+## [0.9.4] - 2026-06-13
+
+### Fixes
+- **HTTP client request timeouts are now configurable** ([#184](https://github.com/gregwinn/winn-lang/issues/184)) — `winn_http` called hackney with only `[{follow_redirect, true}]`, inheriting its 8s-connect / **5s-receive** defaults with no override, so valid-but-slow endpoints (e.g. live "compute on request" APIs) failed with `{error, timeout}`. Each verb now takes an optional trailing options map — `HTTP.get(url, %{timeout: 30000})`, `HTTP.post(url, body, %{connect_timeout: 15000})` — supporting `timeout` / `recv_timeout` / `connect_timeout` (ms) and `follow_redirect`. Defaults are raised to **connect 15s / recv 30s**. Backward compatible: the existing `get/1`, `post/2`, … `request/3` arities are retained and delegate with the new defaults, so no caller changes are required.
+- **Release infrastructure: apt index regeneration** ([#176](https://github.com/gregwinn/winn-lang/issues/176)) — the `update-apt-repo` job ran `gzip -k` (no `-f`), which refused to overwrite the `Packages.gz` committed by a prior release and failed the job under `bash -e`. Added `-f` so the gzipped index regenerates each release.
+
 ## [0.9.3] - 2026-06-10
 
 ### Fixes

--- a/apps/winn/src/winn.app.src
+++ b/apps/winn/src/winn.app.src
@@ -1,6 +1,6 @@
 {application, winn, [
     {description, "The Winn programming language compiler"},
-    {vsn, "0.9.3"},
+    {vsn, "0.9.4"},
     {registered, []},
     {applications, [kernel, stdlib, compiler, cowboy, jsone]},
     {env, []},

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -1076,7 +1076,7 @@ is_tty() ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.3"
+        _         -> "0.9.4"
     end.
 
 print_version() ->

--- a/apps/winn/src/winn_repl.erl
+++ b/apps/winn/src/winn_repl.erl
@@ -230,5 +230,5 @@ get_binding(Name) when is_list(Name) ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.3"
+        _         -> "0.9.4"
     end.


### PR DESCRIPTION
## Summary

**Hotfix release 0.9.4.** Ships the already-merged HTTP client timeout fix (#184) — `winn_http` requests inherited hackney's 5s receive default with no override, so valid-but-slow endpoints failed with `{error, timeout}`. Each verb now takes an optional options map (`HTTP.get(url, %{timeout: 30000})`), and defaults are raised to connect 15s / recv 30s. Backward compatible — original arities retained.

This PR is just the **version bump (0.9.3 → 0.9.4) + CHANGELOG** — the code (`winn_http` `get/2`…`request/4`) already landed on `main` (`fa3fa4d`).

## Released in 0.9.4

- #184 — configurable HTTP timeouts (the fix being shipped).
- #176 — apt index `gzip -kf` release-infra fix (on main since v0.9.3, now in a tagged release; the `update-apt-repo` job should pass this time).

## Verification

- `winn version` → `0.9.4`; `winn_http` beam exports `get/2`, `post/3`, `request/4`.
- `rebar3 eunit`: only the pre-existing `winn_sqlite_tests` esqlite-NIF environmental failure.

After merge: tag `v0.9.4`, GitHub release, Homebrew bump. The timeout fix also needs porting to `develop` (which lacks it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)