### PR TITLE
Back-merge main into develop — recover stranded 0.9.1–0.9.5 hotfixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: "eunit (OTP ${{ matrix.otp }})"
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,11 @@ jobs:
 
       - name: Install nfpm
         run: |
-          curl -sfL https://github.com/goreleaser/nfpm/releases/download/v2.41.1/nfpm_2.41.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin nfpm
+          # Asset is nfpm_<version>_Linux_x86_64.tar.gz (capital L, x86_64)
+          curl -sfL --retry 3 --retry-delay 5 \
+            https://github.com/goreleaser/nfpm/releases/download/v2.41.1/nfpm_2.41.1_Linux_x86_64.tar.gz \
+            | sudo tar xz -C /usr/local/bin nfpm
+          nfpm --version
 
       - name: Extract version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           cd apt-repo
           mkdir -p dists/stable/main/binary-amd64
           dpkg-scanpackages pool/ /dev/null > dists/stable/main/binary-amd64/Packages
-          gzip -k dists/stable/main/binary-amd64/Packages
+          gzip -kf dists/stable/main/binary-amd64/Packages
           cat > dists/stable/Release <<EOF
           Origin: Winn
           Label: Winn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Winn language are documented here.
 
+## [0.9.1] - Unreleased
+
+### Fixes
+- **`Repo.configure` with binary host now works** ([#145](https://github.com/gregwinn/winn-lang/issues/145)) — when Winn code called `Repo.configure(%{host: ...})` the map values were stored as binaries in ETS, and `winn_repo:connect/0` passed them directly to `epgsql:connect/1` → `gen_tcp:connect/4`, which rejects binary hosts with `badarg`. This broke any project reading `DB_HOST` from an env var (the scaffolder default pattern). Fixed by normalizing `host`, `database`, `username`, and `password` to charlists before handing the config to epgsql. The same normalization is applied in `winn_pool:create_one/1` for pooled connections.
+
 ## [0.9.0] - 2026-04-09
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Winn language are documented here.
 
-## [0.9.1] - Unreleased
+## [0.9.1] - 2026-04-12
 
 ### Fixes
 - **`Repo.configure` with binary host now works** ([#145](https://github.com/gregwinn/winn-lang/issues/145)) — when Winn code called `Repo.configure(%{host: ...})` the map values were stored as binaries in ETS, and `winn_repo:connect/0` passed them directly to `epgsql:connect/1` → `gen_tcp:connect/4`, which rejects binary hosts with `badarg`. This broke any project reading `DB_HOST` from an env var (the scaffolder default pattern). Fixed by normalizing `host`, `database`, `username`, and `password` to charlists before handing the config to epgsql. The same normalization is applied in `winn_pool:create_one/1` for pooled connections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Winn language are documented here.
 
+## [0.9.2] - 2026-04-12
+
+### Fixes
+- **`winn_pool` race: trap exits from failed epgsql connects** — `winn_pool:init/1` called `epgsql:connect/1` during startup to build the initial pool. On failure (e.g. `econnrefused` in CI with no database), `epgsql`'s internal `gen_server` terminated with the connect error reason and propagated via the link to `winn_pool`. Without `trap_exit`, the pool inherited that exit and died. The flakiness was masked before v0.9.1 because the earlier binary-host bug crashed `gen_tcp:connect/4` with `badarg` before reaching the link-exit path; fixing #145 unmasked the race. Set `process_flag(trap_exit, true)` in `winn_pool:init/1` so EXIT signals from failed connects become ignorable messages.
+- **Release infrastructure: nfpm asset URL** — the `build-linux-packages` job in `.github/workflows/release.yml` used the wrong nfpm asset name (`linux_amd64` vs the actual `Linux_x86_64`), which 404'd and caused the v0.9.1 `.deb`/`.rpm` builds to fail. Fixed the URL and added curl retry.
+
 ## [0.9.1] - 2026-04-12
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Winn language are documented here.
 
+## [0.9.3] - 2026-06-10
+
+### Fixes
+- **Repeated `_` wildcard in a function head or pattern now compiles** ([#170](https://github.com/gregwinn/winn-lang/issues/170)) — codegen emitted the literal Core Erlang variable `'_'` for every wildcard, so any head/pattern with more than one (e.g. `def head_or([x | _], _)`) was rejected by `core_lint` with `{duplicate_var,'_',...}`. Each `_` is now freshened to a distinct anonymous variable, matching Erlang semantics where repeated `_` is valid. Affects `gen_param`/`gen_pattern` in `winn_codegen_pattern.erl`.
+
 ## [0.9.2] - 2026-04-12
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Winn language are documented here.
 
+## [0.9.4] - 2026-06-13
+
+### Fixes
+- **HTTP client request timeouts are now configurable** ([#184](https://github.com/gregwinn/winn-lang/issues/184)) — `winn_http` called hackney with only `[{follow_redirect, true}]`, inheriting its 8s-connect / **5s-receive** defaults with no override, so valid-but-slow endpoints (e.g. live "compute on request" APIs) failed with `{error, timeout}`. Each verb now takes an optional trailing options map — `HTTP.get(url, %{timeout: 30000})`, `HTTP.post(url, body, %{connect_timeout: 15000})` — supporting `timeout` / `recv_timeout` / `connect_timeout` (ms) and `follow_redirect`. Defaults are raised to **connect 15s / recv 30s**. Backward compatible: the existing `get/1`, `post/2`, … `request/3` arities are retained and delegate with the new defaults, so no caller changes are required.
+- **Release infrastructure: apt index regeneration** ([#176](https://github.com/gregwinn/winn-lang/issues/176)) — the `update-apt-repo` job ran `gzip -k` (no `-f`), which refused to overwrite the `Packages.gz` committed by a prior release and failed the job under `bash -e`. Added `-f` so the gzipped index regenerates each release.
+
 ## [0.9.3] - 2026-06-10
 
 ### Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 rebar3 compile              # Compile everything
-rebar3 eunit                # Run all 537 tests
+rebar3 eunit                # Run all 642 tests
 rebar3 eunit --module=winn_l1_tests  # Run a single test module
 rebar3 escriptize           # Build the winn CLI escript
 ./_build/default/bin/winn help       # Verify CLI works

--- a/apps/winn/src/winn.app.src
+++ b/apps/winn/src/winn.app.src
@@ -1,6 +1,6 @@
 {application, winn, [
     {description, "The Winn programming language compiler"},
-    {vsn, "0.9.0"},
+    {vsn, "0.9.1"},
     {registered, []},
     {applications, [kernel, stdlib, compiler, cowboy, jsone]},
     {env, []},

--- a/apps/winn/src/winn.app.src
+++ b/apps/winn/src/winn.app.src
@@ -1,6 +1,6 @@
 {application, winn, [
     {description, "The Winn programming language compiler"},
-    {vsn, "0.9.1"},
+    {vsn, "0.9.2"},
     {registered, []},
     {applications, [kernel, stdlib, compiler, cowboy, jsone]},
     {env, []},

--- a/apps/winn/src/winn.app.src
+++ b/apps/winn/src/winn.app.src
@@ -1,6 +1,6 @@
 {application, winn, [
     {description, "The Winn programming language compiler"},
-    {vsn, "0.9.2"},
+    {vsn, "0.9.3"},
     {registered, []},
     {applications, [kernel, stdlib, compiler, cowboy, jsone]},
     {env, []},

--- a/apps/winn/src/winn.app.src
+++ b/apps/winn/src/winn.app.src
@@ -1,6 +1,6 @@
 {application, winn, [
     {description, "The Winn programming language compiler"},
-    {vsn, "0.9.3"},
+    {vsn, "0.9.4"},
     {registered, []},
     {applications, [kernel, stdlib, compiler, cowboy, jsone]},
     {env, []},

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -1076,7 +1076,7 @@ is_tty() ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.1"
+        _         -> "0.9.2"
     end.
 
 print_version() ->

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -1076,7 +1076,7 @@ is_tty() ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.0"
+        _         -> "0.9.1"
     end.
 
 print_version() ->

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -1076,7 +1076,7 @@ is_tty() ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.3"
+        _         -> "0.9.4"
     end.
 
 print_version() ->

--- a/apps/winn/src/winn_cli.erl
+++ b/apps/winn/src/winn_cli.erl
@@ -1076,7 +1076,7 @@ is_tty() ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.2"
+        _         -> "0.9.3"
     end.
 
 print_version() ->

--- a/apps/winn/src/winn_codegen_pattern.erl
+++ b/apps/winn/src/winn_codegen_pattern.erl
@@ -13,7 +13,7 @@
 %% After Phase 2 transform, params are always simple variables.
 
 gen_param({var, _, Name})        -> cerl:c_var(var_atom(Name));
-gen_param({pat_wildcard, _})     -> cerl:c_var('_');
+gen_param({pat_wildcard, _})     -> cerl:c_var(fresh_wildcard());
 gen_param({pat_var, _, Name})    -> cerl:c_var(var_atom(Name)).  %% defensive
 
 %% ── Patterns ─────────────────────────────────────────────────────────────
@@ -28,7 +28,7 @@ gen_pattern({pat_var, _Line, Name}) ->
     cerl:c_var(var_atom(Name));
 
 gen_pattern({pat_wildcard, _Line}) ->
-    cerl:c_var('_');
+    cerl:c_var(fresh_wildcard());
 
 gen_pattern({pat_atom, _Line, Value}) ->
     cerl:c_atom(Value);
@@ -48,3 +48,10 @@ gen_pattern({pat_list, _Line, [H | T], Tail}) ->
 
 gen_pattern(Unknown) ->
     error({unsupported_pattern_node, Unknown}).
+
+%% Each `_` wildcard must become a *distinct* Core Erlang variable. Emitting the
+%% literal `'_'` for every wildcard made core_lint reject any pattern/head with
+%% more than one (`{duplicate_var,'_',...}`). A fresh unique name per occurrence
+%% is anonymous in effect (it binds nothing the body uses) and lint-clean. (#170)
+fresh_wildcard() ->
+    list_to_atom("_W" ++ integer_to_list(erlang:unique_integer([monotonic, positive]))).

--- a/apps/winn/src/winn_http.erl
+++ b/apps/winn/src/winn_http.erl
@@ -9,27 +9,44 @@
 %% HTTP.request(method, url, body_or_nil) -> {:ok, %{status, body, headers}}
 
 -module(winn_http).
--export([get/1, post/2, put/2, patch/2, delete/1, request/3]).
+-export([get/1, get/2, post/2, post/3, put/2, put/3, patch/2, patch/3,
+         delete/1, delete/2, request/3, request/4]).
 
+%% Each verb has an optional trailing Opts map (Winn: HTTP.post(url, body, %{...})):
+%%   timeout / recv_timeout (ms, default 30000), connect_timeout (ms, default
+%%   15000), follow_redirect (default true).
 get(Url) when is_binary(Url) ->
-    request(get, Url, nil).
+    request(get, Url, nil, #{}).
+get(Url, Opts) when is_binary(Url), is_map(Opts) ->
+    request(get, Url, nil, Opts).
 
 post(Url, Body) when is_binary(Url) ->
-    request(post, Url, Body).
+    request(post, Url, Body, #{}).
+post(Url, Body, Opts) when is_binary(Url), is_map(Opts) ->
+    request(post, Url, Body, Opts).
 
 put(Url, Body) when is_binary(Url) ->
-    request(put, Url, Body).
+    request(put, Url, Body, #{}).
+put(Url, Body, Opts) when is_binary(Url), is_map(Opts) ->
+    request(put, Url, Body, Opts).
 
 patch(Url, Body) when is_binary(Url) ->
-    request(patch, Url, Body).
+    request(patch, Url, Body, #{}).
+patch(Url, Body, Opts) when is_binary(Url), is_map(Opts) ->
+    request(patch, Url, Body, Opts).
 
 delete(Url) when is_binary(Url) ->
-    request(delete, Url, nil).
+    request(delete, Url, nil, #{}).
+delete(Url, Opts) when is_binary(Url), is_map(Opts) ->
+    request(delete, Url, nil, Opts).
 
 request(Method, Url, Body) ->
+    request(Method, Url, Body, #{}).
+
+request(Method, Url, Body, Opts) ->
     ensure_started(),
     {ReqHeaders, ReqBody} = encode_body(Body),
-    case hackney:request(Method, Url, ReqHeaders, ReqBody, [{follow_redirect, true}]) of
+    case hackney:request(Method, Url, ReqHeaders, ReqBody, hackney_opts(Opts)) of
         {ok, StatusCode, RespHeaders, ClientRef} ->
             case hackney:body(ClientRef) of
                 {ok, RespBody} ->
@@ -51,6 +68,17 @@ request(Method, Url, Body) ->
     end.
 
 %% ── Internal helpers ────────────────────────────────────────────────────
+
+%% Per-call options -> hackney options. Defaults are generous because hackney's
+%% own defaults (8s connect / 5s recv) are too aggressive for slower APIs; all
+%% are overridable per request. `timeout` is an alias for the receive timeout.
+hackney_opts(Opts) when is_map(Opts) ->
+    Recv = maps:get(recv_timeout, Opts, maps:get(timeout, Opts, 30000)),
+    Conn = maps:get(connect_timeout, Opts, 15000),
+    Redirect = maps:get(follow_redirect, Opts, true),
+    [{follow_redirect, Redirect}, {connect_timeout, Conn}, {recv_timeout, Recv}];
+hackney_opts(_) ->
+    [{follow_redirect, true}, {connect_timeout, 15000}, {recv_timeout, 30000}].
 
 ensure_started() ->
     _ = application:ensure_all_started(hackney),

--- a/apps/winn/src/winn_lsp.erl
+++ b/apps/winn/src/winn_lsp.erl
@@ -47,7 +47,7 @@ handle_message(#{<<"method">> := <<"initialize">>, <<"id">> := Id} = _Msg, State
         },
         <<"serverInfo">> => #{
             <<"name">> => <<"winn-lsp">>,
-            <<"version">> => <<"0.9.0">>
+            <<"version">> => <<"0.9.1">>
         }
     },
     send_response(Id, Result),

--- a/apps/winn/src/winn_lsp.erl
+++ b/apps/winn/src/winn_lsp.erl
@@ -47,7 +47,7 @@ handle_message(#{<<"method">> := <<"initialize">>, <<"id">> := Id} = _Msg, State
         },
         <<"serverInfo">> => #{
             <<"name">> => <<"winn-lsp">>,
-            <<"version">> => <<"0.9.1">>
+            <<"version">> => <<"0.9.2">>
         }
     },
     send_response(Id, Result),

--- a/apps/winn/src/winn_pool.erl
+++ b/apps/winn/src/winn_pool.erl
@@ -116,10 +116,7 @@ create_connections(Config, N) ->
     {Conns, Errors}.
 
 create_one(Config) ->
-    #{host := Host, port := Port, database := DB,
-      username := User, password := Pass} = Config,
-    epgsql:connect(#{host => Host, port => Port, database => DB,
-                     username => User, password => Pass}).
+    epgsql:connect(winn_repo:normalize_epgsql_config(Config)).
 
 is_alive(Conn) when is_pid(Conn) ->
     erlang:is_process_alive(Conn);

--- a/apps/winn/src/winn_pool.erl
+++ b/apps/winn/src/winn_pool.erl
@@ -37,6 +37,14 @@ status() ->
 %% ── GenServer callbacks ──────────────────────────────────────────────────────
 
 init(Config) ->
+    %% Trap exits so that links from failed epgsql:connect/1 attempts
+    %% (epgsql's internal gen_server terminates with the connect error
+    %% and propagates via the link) arrive as {'EXIT', Pid, Reason}
+    %% messages instead of killing the pool. Without this, a failed
+    %% initial connection attempt in create_connections/2 would take
+    %% down the whole pool with the connection's exit reason (e.g.
+    %% econnrefused) — flaky because of timing.
+    process_flag(trap_exit, true),
     PoolSize = maps:get(pool_size, Config, ?DEFAULT_POOL_SIZE),
     ConnConfig = maps:without([pool_size], Config),
     %% Create initial connections

--- a/apps/winn/src/winn_repl.erl
+++ b/apps/winn/src/winn_repl.erl
@@ -230,5 +230,5 @@ get_binding(Name) when is_list(Name) ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.0"
+        _         -> "0.9.1"
     end.

--- a/apps/winn/src/winn_repl.erl
+++ b/apps/winn/src/winn_repl.erl
@@ -230,5 +230,5 @@ get_binding(Name) when is_list(Name) ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.1"
+        _         -> "0.9.2"
     end.

--- a/apps/winn/src/winn_repl.erl
+++ b/apps/winn/src/winn_repl.erl
@@ -230,5 +230,5 @@ get_binding(Name) when is_list(Name) ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.2"
+        _         -> "0.9.3"
     end.

--- a/apps/winn/src/winn_repl.erl
+++ b/apps/winn/src/winn_repl.erl
@@ -230,5 +230,5 @@ get_binding(Name) when is_list(Name) ->
 get_version() ->
     case application:get_key(winn, vsn) of
         {ok, Vsn} -> Vsn;
-        _         -> "0.9.3"
+        _         -> "0.9.4"
     end.

--- a/apps/winn/src/winn_repo.erl
+++ b/apps/winn/src/winn_repo.erl
@@ -7,7 +7,7 @@
     'query.new'/1, 'query.where'/3, 'query.limit'/2,
     'query.order_by'/3, 'query.select'/2, 'query.count'/1,
     sql_for_insert/2, sql_for_select/2,
-    build_where/1
+    build_where/1, normalize_epgsql_config/1
 ]).
 
 %% Configure the database connection from Winn:
@@ -69,11 +69,29 @@ connect() ->
         sqlite ->
             winn_repo_sqlite:connect(Config);
         _ ->
-            #{host := Host, port := Port, database := DB,
-              username := User, password := Pass} = Config,
-            epgsql:connect(#{host => Host, port => Port, database => DB,
-                             username => User, password => Pass})
+            epgsql:connect(normalize_epgsql_config(Config))
     end.
+
+%% Normalize a db config map into the shape epgsql expects.
+%% Winn code calls `Repo.configure(%{host: "...", ...})` which stores
+%% the values as binaries in ETS. epgsql forwards `host` to
+%% `gen_tcp:connect/4` which rejects binaries, so we must convert
+%% string-like fields to charlists before calling epgsql:connect/1.
+%%
+%% Normalizes in place so callers can pass additional epgsql options
+%% (ssl, ssl_opts, timeout, connect_timeout, ...) without losing them.
+normalize_epgsql_config(Config) when is_map(Config) ->
+    StringKeys = [host, database, username, password],
+    lists:foldl(fun(Key, Acc) ->
+        case maps:find(Key, Acc) of
+            {ok, V} -> Acc#{Key => to_charlist(V)};
+            error   -> Acc
+        end
+    end, Config, StringKeys).
+
+to_charlist(V) when is_binary(V) -> binary_to_list(V);
+to_charlist(V) when is_list(V)   -> V;
+to_charlist(V) when is_atom(V)   -> atom_to_list(V).
 
 adapter() ->
     maps:get(adapter, db_config(), postgres).

--- a/apps/winn/test/winn_bench_tests.erl
+++ b/apps/winn/test/winn_bench_tests.erl
@@ -28,31 +28,35 @@ percentile_p99_test() ->
 
 %% ── Run a simple benchmark ──────────────────────────────────────────────────
 
-run_simple_bench_test() ->
-    Counter = counters:new(1, []),
-    Results = winn_bench:run(test_bench, #{concurrent => 2, duration => 1}, fun() ->
-        counters:add(Counter, 1, 1),
-        ok
-    end),
-    ?assert(maps:get(total, Results) > 0),
-    ?assert(maps:get(avg, Results) >= 0),
-    ?assertEqual(0, maps:get(errors, Results)),
-    ?assert(maps:get(p50, Results) >= 0),
-    ?assert(maps:get(p99, Results) >= 0).
+run_simple_bench_test_() ->
+    {timeout, 30, fun() ->
+        Counter = counters:new(1, []),
+        Results = winn_bench:run(test_bench, #{concurrent => 2, duration => 1}, fun() ->
+            counters:add(Counter, 1, 1),
+            ok
+        end),
+        ?assert(maps:get(total, Results) > 0),
+        ?assert(maps:get(avg, Results) >= 0),
+        ?assertEqual(0, maps:get(errors, Results)),
+        ?assert(maps:get(p50, Results) >= 0),
+        ?assert(maps:get(p99, Results) >= 0)
+    end}.
 
 %% ── Bench with errors ───────────────────────────────────────────────────────
 
-run_bench_with_errors_test() ->
-    Counter = counters:new(1, []),
-    Results = winn_bench:run(error_bench, #{concurrent => 1, duration => 1}, fun() ->
-        counters:add(Counter, 1, 1),
-        case counters:get(Counter, 1) rem 3 of
-            0 -> error(intentional);
-            _ -> ok
-        end
-    end),
-    ?assert(maps:get(errors, Results) > 0),
-    ?assert(maps:get(error_rate, Results) > 0).
+run_bench_with_errors_test_() ->
+    {timeout, 30, fun() ->
+        Counter = counters:new(1, []),
+        Results = winn_bench:run(error_bench, #{concurrent => 1, duration => 1}, fun() ->
+            counters:add(Counter, 1, 1),
+            case counters:get(Counter, 1) rem 3 of
+                0 -> error(intentional);
+                _ -> ok
+            end
+        end),
+        ?assert(maps:get(errors, Results) > 0),
+        ?assert(maps:get(error_rate, Results) > 0)
+    end}.
 
 %% ── Format results ──────────────────────────────────────────────────────────
 

--- a/apps/winn/test/winn_generator_tests.erl
+++ b/apps/winn/test/winn_generator_tests.erl
@@ -6,43 +6,43 @@
 
 %% ── CLI parse args ──────────────────────────────────────────────────────────
 
-parse_create_model_test() ->
+parse_create_model_args_test() ->
     ?assertEqual({create, ["model", "User", "name:string"]},
                  winn_cli:parse_args(["create", "model", "User", "name:string"])).
 
-parse_c_shorthand_test() ->
+parse_g_shorthand_maps_to_create_test() ->
     ?assertEqual({create, ["model", "User"]},
-                 winn_cli:parse_args(["c", "model", "User"])).
+                 winn_cli:parse_args(["g", "model", "User"])).
 
-parse_create_scaffold_test() ->
+parse_create_scaffold_with_fields_test() ->
     ?assertEqual({create, ["scaffold", "Post", "title:string", "body:text"]},
                  winn_cli:parse_args(["create", "scaffold", "Post", "title:string", "body:text"])).
 
 %% ── Field parsing ───────────────────────────────────────────────────────────
 
-parse_fields_test() ->
+parse_fields_splits_colon_pairs_test() ->
     ?assertEqual([{"name", "string"}, {"age", "integer"}],
                  winn_generator:parse_fields(["name:string", "age:integer"])).
 
-parse_fields_empty_test() ->
+parse_fields_returns_empty_for_no_args_test() ->
     ?assertEqual([], winn_generator:parse_fields([])).
 
-parse_fields_invalid_test() ->
+parse_fields_skips_args_without_colon_test() ->
     ?assertEqual([{"name", "string"}],
                  winn_generator:parse_fields(["name:string", "invalid"])).
 
 %% ── Model generator ────────────────────────────────────────────────────────
 
-model_generates_file_test() ->
+model_generates_schema_file_in_models_dir_test() ->
     %% Generate in a temp directory
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    ok = filelib:ensure_path(TmpDir ++ "/src/models"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(model, ["User", "name:string", "email:string"]),
 
-    {ok, Content} = file:read_file("src/user.winn"),
+    {ok, Content} = file:read_file("src/models/user.winn"),
     ?assert(binary:match(Content, <<"module User">>) =/= nomatch),
     ?assert(binary:match(Content, <<"use Winn.Schema">>) =/= nomatch),
     ?assert(binary:match(Content, <<"schema \"users\"">>) =/= nomatch),
@@ -55,15 +55,15 @@ model_generates_file_test() ->
 
 %% ── Task generator ─────────────────────────────────────────────────────────
 
-task_generates_file_test() ->
+task_generates_file_in_tasks_dir_test() ->
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir),
+    ok = filelib:ensure_path(TmpDir ++ "/src/tasks"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(task, ["db:seed"]),
 
-    {ok, Content} = file:read_file("tasks/db_seed.winn"),
+    {ok, Content} = file:read_file("src/tasks/db_seed.winn"),
     ?assert(binary:match(Content, <<"module Tasks.Db.Seed">>) =/= nomatch),
     ?assert(binary:match(Content, <<"use Winn.Task">>) =/= nomatch),
     ?assert(binary:match(Content, <<"def run(args)">>) =/= nomatch),
@@ -73,16 +73,16 @@ task_generates_file_test() ->
 
 %% ── Router generator ───────────────────────────────────────────────────────
 
-router_generates_file_test() ->
+router_generates_controller_in_controllers_dir_test() ->
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    ok = filelib:ensure_path(TmpDir ++ "/src/controllers"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(router, ["Api"]),
 
-    {ok, Content} = file:read_file("src/api.winn"),
-    ?assert(binary:match(Content, <<"module Api">>) =/= nomatch),
+    {ok, Content} = file:read_file("src/controllers/api_controller.winn"),
+    ?assert(binary:match(Content, <<"module ApiController">>) =/= nomatch),
     ?assert(binary:match(Content, <<"use Winn.Router">>) =/= nomatch),
     ?assert(binary:match(Content, <<"def routes()">>) =/= nomatch),
 
@@ -91,15 +91,15 @@ router_generates_file_test() ->
 
 %% ── Migration generator ────────────────────────────────────────────────────
 
-migration_generates_file_test() ->
+migration_generates_timestamped_file_in_db_dir_test() ->
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir),
+    ok = filelib:ensure_path(TmpDir ++ "/db/migrations"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(migration, ["CreateUsers", "name:string", "email:string"]),
 
-    Files = filelib:wildcard("migrations/*.winn"),
+    Files = filelib:wildcard("db/migrations/*.winn"),
     ?assertEqual(1, length(Files)),
     {ok, Content} = file:read_file(hd(Files)),
     ?assert(binary:match(Content, <<"module Migrations.CreateUsers">>) =/= nomatch),
@@ -111,21 +111,23 @@ migration_generates_file_test() ->
 
 %% ── Scaffold generator ─────────────────────────────────────────────────────
 
-scaffold_generates_files_test() ->
+scaffold_generates_model_controller_and_test_test() ->
     OldDir = file:get_cwd(),
     TmpDir = "/tmp/winn_gen_test_" ++ integer_to_list(erlang:unique_integer([positive])),
-    ok = filelib:ensure_path(TmpDir ++ "/src"),
+    ok = filelib:ensure_path(TmpDir ++ "/src/models"),
+    ok = filelib:ensure_path(TmpDir ++ "/src/controllers"),
+    ok = filelib:ensure_path(TmpDir ++ "/test"),
     file:set_cwd(TmpDir),
 
     winn_generator:generate(scaffold, ["Post", "title:string", "body:text"]),
 
-    ?assert(filelib:is_file("src/post.winn")),
-    ?assert(filelib:is_file("src/post_router.winn")),
+    ?assert(filelib:is_file("src/models/post.winn")),
+    ?assert(filelib:is_file("src/controllers/post_controller.winn")),
     ?assert(filelib:is_file("test/post_test.winn")),
 
-    {ok, RouterContent} = file:read_file("src/post_router.winn"),
-    ?assert(binary:match(RouterContent, <<"PostRouter">>) =/= nomatch),
-    ?assert(binary:match(RouterContent, <<"Post.all()">>) =/= nomatch),
+    {ok, ControllerContent} = file:read_file("src/controllers/post_controller.winn"),
+    ?assert(binary:match(ControllerContent, <<"PostController">>) =/= nomatch),
+    ?assert(binary:match(ControllerContent, <<"Post.all()">>) =/= nomatch),
 
     file:set_cwd(element(2, OldDir)),
     os:cmd("rm -rf " ++ TmpDir).

--- a/apps/winn/test/winn_pool_tests.erl
+++ b/apps/winn/test/winn_pool_tests.erl
@@ -19,12 +19,27 @@ configure_pool_size_test() ->
 %% ── pool_status when pool not started ───────────────────────────────────────
 
 pool_not_started_test() ->
-    %% Ensure pool is not running
+    %% Ensure pool is not running. gen_server:stop may return with a
+    %% non-normal reason when the pool's linked connection attempts
+    %% failed (econnrefused in CI with no DB) — swallow those since we
+    %% only care that the process is gone afterwards.
     case whereis(winn_pool) of
         undefined -> ok;
-        Pid -> gen_server:stop(Pid)
+        Pid ->
+            try gen_server:stop(Pid, normal, 1000)
+            catch exit:_ -> ok
+            end,
+            %% Wait for the name to actually be released
+            wait_for_unregister(winn_pool, 20)
     end,
     ?assertEqual({error, pool_not_started}, winn_repo:pool_status()).
+
+wait_for_unregister(_Name, 0) -> timeout;
+wait_for_unregister(Name, N) ->
+    case whereis(Name) of
+        undefined -> ok;
+        _ -> timer:sleep(50), wait_for_unregister(Name, N - 1)
+    end.
 
 %% ── Repo exports pool functions ─────────────────────────────────────────────
 

--- a/apps/winn/test/winn_repo_config_tests.erl
+++ b/apps/winn/test/winn_repo_config_tests.erl
@@ -67,3 +67,72 @@ configure_from_winn_test() ->
     ok = ModName:run(),
     ?assertEqual(<<"myhost">>, winn_config:get(repo, host)),
     ?assertEqual(<<"mydb">>, winn_config:get(repo, database)).
+
+%% ── Binary → charlist normalization for epgsql (#145) ──────────────────────
+
+normalize_epgsql_config_converts_binaries_to_charlists_test() ->
+    Config = #{
+        host     => <<"postgresql.databases.svc.cluster.local">>,
+        port     => 5432,
+        database => <<"myapp">>,
+        username => <<"postgres">>,
+        password => <<"secret">>
+    },
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual("postgresql.databases.svc.cluster.local", maps:get(host, Normalized)),
+    ?assertEqual(5432, maps:get(port, Normalized)),
+    ?assertEqual("myapp", maps:get(database, Normalized)),
+    ?assertEqual("postgres", maps:get(username, Normalized)),
+    ?assertEqual("secret", maps:get(password, Normalized)).
+
+normalize_epgsql_config_passes_through_charlists_test() ->
+    Config = #{
+        host     => "localhost",
+        port     => 5432,
+        database => "winn_dev",
+        username => "postgres",
+        password => ""
+    },
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual("localhost", maps:get(host, Normalized)),
+    ?assertEqual("winn_dev", maps:get(database, Normalized)),
+    ?assertEqual("postgres", maps:get(username, Normalized)),
+    ?assertEqual("", maps:get(password, Normalized)).
+
+normalize_epgsql_config_handles_atom_host_test() ->
+    Config = #{
+        host     => localhost,
+        port     => 5432,
+        database => <<"mydb">>,
+        username => <<"u">>,
+        password => <<"p">>
+    },
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual("localhost", maps:get(host, Normalized)).
+
+normalize_epgsql_config_preserves_extra_keys_test() ->
+    %% epgsql supports ssl, ssl_opts, timeout, connect_timeout, etc.
+    %% The normalizer must not drop them.
+    Config = #{
+        host          => <<"db.example.com">>,
+        port          => 5432,
+        database      => <<"mydb">>,
+        username      => <<"u">>,
+        password      => <<"p">>,
+        ssl           => required,
+        ssl_opts      => [{verify, verify_peer}],
+        timeout       => 10000
+    },
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual(required, maps:get(ssl, Normalized)),
+    ?assertEqual([{verify, verify_peer}], maps:get(ssl_opts, Normalized)),
+    ?assertEqual(10000, maps:get(timeout, Normalized)),
+    ?assertEqual("db.example.com", maps:get(host, Normalized)).
+
+normalize_epgsql_config_tolerates_missing_keys_test() ->
+    %% Exported function: callers may pass partial maps. Should not crash.
+    Config = #{host => <<"db.example.com">>, port => 5432},
+    Normalized = winn_repo:normalize_epgsql_config(Config),
+    ?assertEqual("db.example.com", maps:get(host, Normalized)),
+    ?assertEqual(5432, maps:get(port, Normalized)),
+    ?assertEqual(error, maps:find(database, Normalized)).

--- a/apps/winn/test/winn_wildcard_tests.erl
+++ b/apps/winn/test/winn_wildcard_tests.erl
@@ -1,0 +1,57 @@
+%% winn_wildcard_tests.erl — regression tests for repeated `_` wildcards (#170).
+%%
+%% Each `_` must compile to a distinct Core Erlang variable; emitting the literal
+%% `'_'` for every wildcard made core_lint reject any pattern/head with more than
+%% one (`{duplicate_var,'_',...}`).
+
+-module(winn_wildcard_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_and_load(Source) ->
+    {ok, RawTokens, _} = winn_lexer:string(Source),
+    Tokens = winn_newline_filter:filter(RawTokens),
+    {ok, AST}       = winn_parser:parse(Tokens),
+    Transformed     = winn_transform:transform(AST),
+    [CoreMod]       = winn_codegen:gen(Transformed),
+    {ok, ModName, Bin} = compile:forms(CoreMod, [from_core, return_errors]),
+    code:purge(ModName),
+    {module, ModName} = code:load_binary(ModName, "test", Bin),
+    ModName.
+
+%% Two `_` across one function head (the originally reported repro).
+repeated_wildcard_in_head_test() ->
+    Src = "module DupWildHead\n"
+          "  def head_or([x | _], _)\n"
+          "    x\n"
+          "  end\n"
+          "  def head_or(_list, fallback)\n"
+          "    fallback\n"
+          "  end\n"
+          "end\n",
+    Mod = compile_and_load(Src),
+    ?assertEqual(1, Mod:head_or([1, 2, 3], 0)),
+    ?assertEqual(0, Mod:head_or([], 0)).
+
+%% Two `_` inside a single tuple pattern.
+repeated_wildcard_in_tuple_test() ->
+    Src = "module DupWildTuple\n"
+          "  def third({_, _, c})\n"
+          "    c\n"
+          "  end\n"
+          "end\n",
+    Mod = compile_and_load(Src),
+    ?assertEqual(3, Mod:third({1, 2, 3})).
+
+%% Wildcards in a switch clause pattern alongside a head wildcard.
+repeated_wildcard_in_switch_test() ->
+    Src = "module DupWildSwitch\n"
+          "  def tag(_ignored, pair)\n"
+          "    switch pair\n"
+          "      {_, _} => :two\n"
+          "      _ => :other\n"
+          "    end\n"
+          "  end\n"
+          "end\n",
+    Mod = compile_and_load(Src),
+    ?assertEqual(two, Mod:tag(0, {1, 2})),
+    ?assertEqual(other, Mod:tag(0, 5)).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,21 @@
 ## Install
 
 ```sh
+# macOS
 brew tap gregwinn/winn && brew install winn
+
+# Linux (curl)
+curl -fsSL https://winn.ws/install.sh | bash
+
+# Ubuntu / Debian
+curl -fsSL https://winn.ws/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/winn.gpg
+echo "deb [signed-by=/usr/share/keyrings/winn.gpg] https://gregwinn.github.io/apt.winn.ws stable main" \
+  | sudo tee /etc/apt/sources.list.d/winn.list
+sudo apt update && sudo apt install winn
+
+# Fedora / RHEL
+sudo dnf config-manager --add-repo https://gregwinn.github.io/rpm.winn.ws/winn.repo
+sudo dnf install winn
 ```
 
 ## Quick Reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,22 @@ brew tap gregwinn/winn
 brew install winn
 ```
 
+### Ubuntu / Debian (apt)
+
+```sh
+curl -fsSL https://winn.ws/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/winn.gpg
+echo "deb [signed-by=/usr/share/keyrings/winn.gpg] https://gregwinn.github.io/apt.winn.ws stable main" \
+  | sudo tee /etc/apt/sources.list.d/winn.list
+sudo apt update && sudo apt install winn
+```
+
+### Fedora / RHEL (dnf)
+
+```sh
+sudo dnf config-manager --add-repo https://gregwinn.github.io/rpm.winn.ws/winn.repo
+sudo dnf install winn
+```
+
 ### From Source
 
 ```sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ Requires Erlang/OTP 25+ and rebar3.
 
 ```sh
 winn version
-# => winn 0.9.1
+# => winn 0.9.2
 
 winn help
 ```
@@ -73,7 +73,7 @@ winn help
 You should see:
 
 ```
-Winn 0.9.1 - a compiled language on the BEAM
+Winn 0.9.2 - a compiled language on the BEAM
 
 Usage:
   winn new <name>         Create a new Winn project

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ Requires Erlang/OTP 25+ and rebar3.
 
 ```sh
 winn version
-# => winn 0.9.0
+# => winn 0.9.1
 
 winn help
 ```
@@ -73,7 +73,7 @@ winn help
 You should see:
 
 ```
-Winn 0.9.0 - a compiled language on the BEAM
+Winn 0.9.1 - a compiled language on the BEAM
 
 Usage:
   winn new <name>         Create a new Winn project

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Winn Roadmap
 
-## Current Status — v0.9.1
+## Current Status — v0.9.2
 
 642 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics. LSP with inline errors and autocomplete.
 
@@ -18,6 +18,7 @@
 | v0.8.0 | Web Framework + Agents | Static files, CORS, auth middleware, health checks, `agent` keyword with `@state` syntax and `async def`, compiles to GenServer |
 | v0.9.0 | Developer Tooling | `winn fmt`, `winn lint` (10 rules), `winn lsp` (diagnostics + autocomplete), improved `winn new` (--api, --minimal), command shortcuts, codegen split |
 | v0.9.1 | Bug fix | `Repo.configure` binary host crashing epgsql connect ([#145](https://github.com/gregwinn/winn-lang/issues/145)) |
+| v0.9.2 | Bug fix | `winn_pool` race: trap exits from failed epgsql connects + release infra nfpm URL fix |
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Winn Roadmap
 
-## Current Status — v0.9.0
+## Current Status — v0.9.1
 
-635 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics. LSP with inline errors and autocomplete.
+642 tests passing. Homebrew install (`brew install gregwinn/winn/winn`). VS Code extension with syntax highlighting and compile-on-save diagnostics. LSP with inline errors and autocomplete.
 
 ### What's Shipped
 
@@ -17,6 +17,7 @@
 | v0.7.0 | Core Stdlib + Packages | File I/O, Regex, Timer, Retry, DateTime/String, package system (`winn add`/`winn remove`), [winn-redis](https://github.com/gregwinn/winn-redis), [winn-mongodb](https://github.com/gregwinn/winn-mongodb), [winn-amqp](https://github.com/gregwinn/winn-amqp) |
 | v0.8.0 | Web Framework + Agents | Static files, CORS, auth middleware, health checks, `agent` keyword with `@state` syntax and `async def`, compiles to GenServer |
 | v0.9.0 | Developer Tooling | `winn fmt`, `winn lint` (10 rules), `winn lsp` (diagnostics + autocomplete), improved `winn new` (--api, --minimal), command shortcuts, codegen split |
+| v0.9.1 | Bug fix | `Repo.configure` binary host crashing epgsql connect ([#145](https://github.com/gregwinn/winn-lang/issues/145)) |
 
 ---
 


### PR DESCRIPTION
## Why

Patch releases 0.9.1–0.9.4 were cut as `hotfix/*` branches off `main` and never back-merged. `origin/main` was 18 commits ahead of `origin/develop`, and `develop` had **regressed two already-released runtime fixes** plus both release-workflow fixes.

Cutting v0.10.0 from `develop` today would have reintroduced two bugs users already saw fixed, and the release job would have failed to publish the apt index.

The `gen_tcp:connect/4 badarg` crash was actively reproducing in `rebar3 eunit` on `develop`, with `trap_exit: false` on `winn_pool` in the same crash report.

## What this recovers from `main`

| Fix | Shipped in | Impact of its absence on develop |
|---|---|---|
| `winn_repo:normalize_epgsql_config/1` (#145) | 0.9.1 | Binary `host`/`database`/`username`/`password` from `Repo.configure` crash `gen_tcp:connect/4` with `badarg` — breaks every project reading `DB_HOST` from an env var (the scaffolder default) |
| `process_flag(trap_exit, true)` in `winn_pool:init/1` | 0.9.2 | A failed epgsql connect propagates its exit through the link and kills the whole pool |
| `release.yml`: nfpm asset URL + retry | 0.9.2 | `.deb`/`.rpm` build job 404s |
| `release.yml`: `gzip -kf` | 0.9.4 | apt `Packages.gz` regeneration fails under `bash -e` |
| apt/dnf install docs | 0.9.1 | Missing from `docs/cli.md`, `docs/getting-started.md` |
| Version `0.9.0` → `0.9.4` | — | `winn.app.src`, `winn_cli.erl`, `winn_repl.erl` all still claimed 0.9.0 |

## Conflict resolutions

- **`winn_repo.erl`** — union of both export lists. Kept develop's `row_to_map_cols/2` at every call site (#172 — map result rows via DB column metadata rather than the schema field list) and dropped main's older `row_to_map/2`. Added main's `normalize_epgsql_config/1` + `to_charlist/1`. Net: both fixes coexist, neither is lost.
- **`CHANGELOG.md`** — kept develop's `[Unreleased]`, appended main's released `[0.9.4]`/`[0.9.3]`/`[0.9.2]`/`[0.9.1]` sections above `[0.9.0]`.
- **`CLAUDE.md`** — test count set to the current actual (774).

## Verification

`rebar3 eunit`: **774 tests**. The epgsql `badarg` crash report no longer appears anywhere in the run, and the 13 ported `winn_pool_tests` + `winn_repo_config_tests` pass.

Three pre-existing environment-dependent failures remain, none related to this merge:
- `winn_m1_tests:get_httpbin_test` — httpbin.org returning 503
- `winn_sqlite_tests:sqlite_connect_test` — local `esqlite3` NIF load failure
- `winn_auth_scaffold_tests:files_exist` — order-dependent; passes in isolation, and leaks `/tmp/winn_auth_scaffold_*` dirs between runs

## Follow-up

`CLAUDE.md`'s workflow rules cover only the feature-branch-off-`develop` path and say nothing about back-merging after a hotfix — which is how this drifted for four releases. Worth adding a rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFuxfVkz7ixzETv8CnyVdS